### PR TITLE
프록시 서버 퀴즈 정보 조회 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from './users/users.module';
+import { QuizModule } from './quiz/quiz.module';
 
 @Module({
     imports: [
@@ -16,6 +17,7 @@ import { UsersModule } from './users/users.module';
             synchronize: true,
         }),
         UsersModule,
+        QuizModule,
     ],
     controllers: [AppController],
     providers: [AppService],

--- a/backend/src/quiz/quiz.controller.spec.ts
+++ b/backend/src/quiz/quiz.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuizController } from './quiz.controller';
+
+describe('QuizController', () => {
+  let controller: QuizController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuizController],
+    }).compile();
+
+    controller = module.get<QuizController>(QuizController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/quiz/quiz.controller.ts
+++ b/backend/src/quiz/quiz.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { QuizService } from './quiz.service';
+
+@Controller('quiz')
+export class QuizController {
+    constructor(private quizService: QuizService) {}
+
+    @Get('/:id')
+    getQuizById(@Param('id', ParseIntPipe) id: number) {
+        return this.quizService.getQuizById(id)
+    }
+}

--- a/backend/src/quiz/quiz.entity.ts
+++ b/backend/src/quiz/quiz.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Quiz {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column()
+  content: string;
+}

--- a/backend/src/quiz/quiz.module.ts
+++ b/backend/src/quiz/quiz.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { QuizController } from './quiz.controller';
+import { QuizService } from './quiz.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Quiz } from './quiz.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Quiz])],
+  controllers: [QuizController],
+  providers: [QuizService]
+})
+export class QuizModule {}

--- a/backend/src/quiz/quiz.service.spec.ts
+++ b/backend/src/quiz/quiz.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuizService } from './quiz.service';
+
+describe('QuizService', () => {
+  let service: QuizService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [QuizService],
+    }).compile();
+
+    service = module.get<QuizService>(QuizService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Quiz } from './quiz.entity';
+
+@Injectable()
+export class QuizService {
+    constructor(
+        @InjectRepository(Quiz)
+        private quizRepository: Repository<Quiz>
+    ) {}
+
+    getQuizById(id: number) {
+        return this.quizRepository.findOneByOrFail({ id });
+    }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,7 +13,8 @@
     "noImplicitAny": true,
     "strictBindCallApply": true,
     "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "strictPropertyInitialization": false
   },
   "extends": "@tsconfig/node20/tsconfig.json"
 }


### PR DESCRIPTION
## 작업 개요
closes #16 

프록시 서버는 GET `/quiz/:id` 요청을 받으면 quiz id, quiz title, quiz content를 반환한다.

## 작업 상세 내용

- quiz 모듈 추가
- quiz 조회 API 추가
- quiz.entity.ts
  - id, title, content를 속성으로 갖는 엔티티 생성
- strictPropertyInitialization
  - entity 작성 시, 생성자 없이도 속성을 갖게 하는 tsconfig 옵션 추가

## 문제점 혹은 고민(선택)
- 없는 id로 요청을 보내면 typeorm의 exception이 발생한다. 이 예외를 적절한 status code를 갖는 Error로 변환하여 전달해야 하는데, 이는 exception 처리에 대한 issue로 분리할 계획이다.
- session이 없는 사용자의 요청은 거부되어야 한다. 관련된 issue가 있으므로 session 발급을 담당하는 issue를 해결할 때 같이 처리할 계획이다.