### PR TITLE
사이드바 컴포넌트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+package-lock.json

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,13 @@
     <head>
         <meta charset="UTF-8" />
         <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" as="style" crossorigin="" />
+        <link
+            rel="stylesheet"
+            as="style"
+            crossorigin
+            href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
+        />
         <title>Vite + React + TS</title>
     </head>
     <body>

--- a/frontend/src/asset/dropDown.svg
+++ b/frontend/src/asset/dropDown.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="1000px" height="1000px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+
+<rect x="0" fill="none" width="24" height="24"/>
+
+<g>
+
+<path d="M7 10l5 5 5-5" fill="#999999"/>
+
+</g>
+
+</svg>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import dropDownImage from '../asset/dropDown.svg';
+import StartButton from './StartButton';
+
+const links = [
+    { title: 'Home', path: '/' },
+    { title: 'Docker란?', path: '/what-is-docker' },
+];
+
+const dockerImageLinks = [
+    { title: 'Docker image란?', path: '/what-is-docker-image' },
+    { title: 'image 가져오기', path: '/image/quiz/1' },
+    { title: 'Docker image란?', path: '/image/quiz/2' },
+    { title: 'image 목록 확인하기', path: '/image/quiz/3' },
+    { title: 'image 삭제하기', path: '/image/quiz/4' },
+];
+
+const dockerContainerLinks = [
+    { title: 'Docker Container란?', path: '/what-is-docker-container' },
+    { title: 'Container의 생명주기', path: '/what-is-container-lifecycle' },
+    { title: 'Container 생성하기', path: '/container/quiz/1' },
+    { title: 'Container 실행하기', path: '/container/quiz/2' },
+    { title: 'Container 생성 및 실행하기', path: '/container/quiz/3' },
+    { title: 'Container 목록 확인하기', path: '/container/quiz/4' },
+    { title: 'Container 중지하기', path: '/container/quiz/5' },
+    { title: 'Container 삭제하기', path: '/container/quiz/6' },
+];
+
+type SidebarSectionProps = {
+    title: string;
+    links: Array<{
+        title: string;
+        path: string;
+    }>;
+};
+
+const SidebarSection = ({ title, links }: SidebarSectionProps) => {
+    const [isOpen, setIsOpen] = useState(true);
+
+    const toggleDropdown = () => {
+        setIsOpen((prev) => !prev);
+    };
+
+    return (
+        <>
+            <div className='m-4 flex items-center  border-b-2 border-gray-400 text-xl'>
+                <p>{title}</p>
+                <button onClick={toggleDropdown}>
+                    <img
+                        src={dropDownImage}
+                        className={`transition-transform duration-300 ${isOpen ? '' : 'rotate-180'}`}
+                        style={{ width: '2em', height: '2em' }}
+                    />
+                </button>
+            </div>
+            {isOpen && (
+                <ul>
+                    {links.map((link) => (
+                        <li className='m-4 hover:text-Moby-Blue' key={link.path}>
+                            <a href={link.path}>{link.title}</a>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </>
+    );
+};
+
+const Sidebar = () => {
+    return (
+        <nav className='flex flex-col text-Off-Black h-[calc(100vh-4rem)] font-pretendard bg-gray-100'>
+            <div className='flex-grow'>
+                {links.map((link) => (
+                    <p
+                        className='m-4 pb-2 border-b-2 border-gray-400 text-xl hover:text-Moby-Blue'
+                        key={link.path}
+                    >
+                        <a href={link.path}>{link.title}</a>
+                    </p>
+                ))}
+                <SidebarSection title='Docker Image 학습' links={dockerImageLinks} />
+                <SidebarSection title='Docker Container 학습' links={dockerContainerLinks} />
+            </div>
+            <StartButton />
+        </nav>
+    );
+};
+
+export default Sidebar;

--- a/frontend/src/components/StartButton.tsx
+++ b/frontend/src/components/StartButton.tsx
@@ -1,0 +1,9 @@
+const StartButton = () => {
+    return (
+        <div className=' bg-Moby-Blue py-4 m-4 rounded-lg'>
+            <button className='w-full text-white text-xl'>시작하기</button>
+        </div>
+    );
+};
+
+export default StartButton;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,7 +2,19 @@
 export default {
     content: ['./index.html', './src/**/*.{js,jsx,tsx,ts}'],
     theme: {
-        extend: {},
+        extend: {
+            fontFamily: {
+                pretendard: ['Pretendard', 'sans-serif'],
+            },
+            colors: {
+                'Moby-Blue': '#1D63ED',
+                'Dark-Blue': '#00084D',
+                'Light-Blue': '#E5F2FC',
+                'Off-Black': '#17191E',
+                'Secondary-Green': '#58C126',
+                'Secondary-Red': '#C12626',
+            },
+        },
     },
     plugins: [],
 };

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
@@ -14,13 +15,13 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-
+    
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src"]
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2022",
     "lib": ["ES2023"],
@@ -12,13 +13,13 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
-
+    
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedIndexedAccess": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## 작업 개요
- 관련 이슈
- #4 
- #5 
- #6 
- 사이드바 컴포넌트 구현

## 작업 상세 내용
- [x] 좌측 sidebar 컴포넌트에 Docker Image 학습, Docker Container 학습 항목을 제공하고, dropdown 버튼을 눌러 하위 항목을 드러내고, 하위 항목에 링크를 넣는다.
	- [x] 기반이 되는 html 만들기
	- [x] 기반이 되는 html을 가지고 map 이용해서 정리해보기
	- [x] dropdown 요소 추가
	- [x] css로 꾸미기
- [x] 좌측 sidebar 컴포넌트에 Home, Docker란?, 학습법 항목을 제공하고 링크를 넣는다.
- [x] 좌측 sidebar 컴포넌트 하단에 학습 시작하기 버튼을 제공한다.

## 구현 영상
- ![사이드바예시](https://github.com/user-attachments/assets/44268c99-8f44-424e-90d8-59c25a637664)
- 헤더, 랜딩페이지는 임시입니다
- react-router를 적용하지 않아서 클릭 시 새로고침이 됩니다
- 시작 버튼 뼈대만 만들었습니다.

## 고민 사항
- 사이드바 시작버튼을 클릭하려면 스크롤을 내려야 하는 현상이 있었습니다.
- 원인은 
  - 사이드바를 h-screen으로 화면 높이로 했습니다. 
  - 헤더 컴포넌트가 차지하는 크기 만큼 내려가서 생긴 현상이었습니다.

- 64px로 가정을 하고 h-[calc(100vh-4rem)]으로 높이를 계산 해줬습니다.(100vh는 현재 화면 높이 - 4rem(64px))
- 헤더 컴포넌트의 크기에 따라 수정하면 될 것 같습니다.

시작버튼이 가려져 있음
- ![시작버튼_스크롤](https://github.com/user-attachments/assets/5d3473a4-8f86-4c72-b5c8-6348f2d7934f)

높이 계산해서 시작버튼이 잘 보임
- ![시작버튼_결과](https://github.com/user-attachments/assets/2c5690af-41f9-485c-9a85-8dca32917dfc)

- 그외 사소한 고민사항은 개발일지에 적겠습니다. 참고해주세요
