### PR TITLE
pnpm 마이그레이션과 eslint react rule 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dist
 .pnp.*
 
 package-lock.json
+pnpm-lock.yaml

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,40 +1,21 @@
-import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
 import globals from 'globals';
-import tsParser from '@typescript-eslint/parser';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import js from '@eslint/js';
-import { FlatCompat } from '@eslint/eslintrc';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import react from 'eslint-plugin-react';
+import prettier from 'eslint-config-prettier';
 
-const _filename = fileURLToPath(import.meta.url);
-const _dirname = path.dirname(_filename);
-const compat = new FlatCompat({
-    baseDirectory: _dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all,
-});
+const ignoreList = ['**/node_modules/**/*', '**/dist/**/*', '**/*.js', '**/*.mjs'];
 
-export default [
+export default tseslint.config(
     {
-        ignores: ['**/node_modules/**/*', '**/dist/**/*', '**/*.js', '**/*.mjs'],
-    },
-    ...compat.extends('eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'),
-    {
-        plugins: {
-            '@typescript-eslint': typescriptEslint,
-        },
-
+        extends: [eslint.configs.recommended, ...tseslint.configs.recommended, prettier],
+        ignores: ignoreList,
         languageOptions: {
-            globals: {
-                ...globals.browser,
-                ...globals.node,
-            },
-
-            parser: tsParser,
+            globals: globals.node,
         },
-
         rules: {
             '@typescript-eslint/naming-convention': [
                 'error',
@@ -77,11 +58,15 @@ export default [
     },
     {
         files: ['frontend/**/*.{ts,tsx}'],
-        ignores: ['dist'],
+        ignores: ignoreList,
         languageOptions: {
             ecmaVersion: 2020,
             globals: globals.browser,
         },
+        settings: {
+            react: { version: 'detect' },
+        },
+        extends: [react.configs.flat.recommended, react.configs.flat['jsx-runtime']],
         plugins: {
             'react-hooks': reactHooks,
             'react-refresh': reactRefresh,
@@ -96,10 +81,13 @@ export default [
                     format: ['PascalCase', 'camelCase'],
                 },
             ],
+            'react/no-array-index-key': 'error',
+            'react/function-component-definition': ['error', { namedComponents: 'arrow-function' }],
         },
     },
     {
         files: ['backend/**/*.ts'],
+        ignores: ignoreList,
         languageOptions: {
             parserOptions: {
                 project: 'tsconfig.json',
@@ -113,5 +101,5 @@ export default [
             '@typescript-eslint/explicit-module-boundary-types': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
         },
-    },
-];
+    }
+);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,13 @@
 import Header from './components/Header';
 import LandingPage from './components/LandingPage';
 
-function App() {
+const App = () => {
     return (
         <>
             <Header />
             <LandingPage />
         </>
     );
-}
+};
 
 export default App;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@typescript-eslint/eslint-plugin": "^8.13.0",
     "eslint": "^9.14.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
     "lint": "eslint . ",
     "prettier": "prettier --write ."
   },
-  "workspaces": [
-    "frontend",
-    "backend"
-  ],
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+    - 'frontend/'
+    - 'backend/'


### PR DESCRIPTION
## 작업 개요

closes #156

- npm에서 pnpm으로 변경
- eslint react rule 적용

## 작업 상세 내용

- pnpm workspace 추가
- pnpm-lock.yaml git ignore
- react/jsx-key, react/no-array-index-key 활성화
- @eslint/migrate-config로 설정 파일을 변경하면서 생긴 불필요한 부분 제거
- react component는 'arrow-function'으로 정의하는 규칙 추가
- react +17을 위한 react 플러그인의 jsx-runtime config 추가

## 참고자료(선택)

[pnpm과 eslint 설정 개발 기록 wiki](https://github.com/boostcampwm-2024/web34-LearnDocker/wiki/%EA%B0%9C%EB%B0%9C%EA%B8%B0%EB%A1%9D_J114%EB%B0%95%EC%84%B8%ED%99%98_2%EC%A3%BC6%EC%9D%BC%EC%B0%A8_pnpm-eslint-react)

## 문제점 혹은 고민(선택)