### PR TITLE
exception filter 적용, winston 로거 추가

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,9 +26,11 @@
     "@nestjs/serve-static": "^4.0.2",
     "@nestjs/typeorm": "^10.0.2",
     "mysql2": "^3.11.4",
+    "nest-winston": "^1.9.7",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.20",
+    "winston": "^3.17.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -36,6 +36,7 @@ import { BusinessExceptionsFilter, LastExceptionFilter } from './common/exceptio
             provide: APP_FILTER,
             useClass: BusinessExceptionsFilter,
         },
+        Logger
     ],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from './users/users.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
+import { APP_FILTER } from '@nestjs/core';
+import { BusinessExceptionsFilter, LastExceptionFilter } from './common/exception/filters';
 
 @Module({
     imports: [
@@ -24,6 +26,16 @@ import { join } from 'path';
         }),
     ],
     controllers: [AppController],
-    providers: [AppService],
+    providers: [
+        AppService,
+        {
+            provide: APP_FILTER,
+            useClass: LastExceptionFilter,
+        },
+        {
+            provide: APP_FILTER,
+            useClass: BusinessExceptionsFilter,
+        },
+    ],
 })
 export class AppModule {}

--- a/backend/src/common/exception/errors.ts
+++ b/backend/src/common/exception/errors.ts
@@ -1,0 +1,12 @@
+export class BusinessException extends Error {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
+// 이해를 돕기 위한 샘플로 만들었음. 필요없으면 삭제 가능
+export class PreviousProblemUnsolvedExeption extends BusinessException {
+    constructor() {
+        super('모든 이전 문제를 풀지 않으면 이번 문제를 풀 수 없음');
+    }
+}

--- a/backend/src/common/exception/filters.ts
+++ b/backend/src/common/exception/filters.ts
@@ -5,12 +5,15 @@ import {
     HttpException,
     HttpStatus,
     ForbiddenException,
+    Logger,
 } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
 import { BusinessException, PreviousProblemUnsolvedExeption } from './errors';
 
 @Catch()
 export class LastExceptionFilter implements ExceptionFilter {
+    protected readonly logger = new Logger(this.constructor.name);
+
     constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
 
     catch(exception: unknown, host: ArgumentsHost) {
@@ -29,6 +32,10 @@ export class LastExceptionFilter implements ExceptionFilter {
             path: httpAdapter.getRequestUrl(ctx.getRequest()),
         };
 
+        if (this.constructor.name === 'LastExceptionFilter') {
+          this.logger.error(exception);
+        }
+
         httpAdapter.reply(ctx.getResponse(), responseBody, httpStatus);
     }
 }
@@ -36,10 +43,12 @@ export class LastExceptionFilter implements ExceptionFilter {
 @Catch(BusinessException)
 export class BusinessExceptionsFilter extends LastExceptionFilter {
     catch(exception: unknown, host: ArgumentsHost) {
+        this.logger.log(exception);
+
         // 이해를 돕기 위한 샘플로 만들었음. 필요없으면 삭제 가능
         if (exception instanceof PreviousProblemUnsolvedExeption) {
-          super.catch(new ForbiddenException(exception), host);
-          return;
+            super.catch(new ForbiddenException(exception), host);
+            return;
         }
         super.catch(exception, host);
     }

--- a/backend/src/common/exception/filters.ts
+++ b/backend/src/common/exception/filters.ts
@@ -1,0 +1,46 @@
+import {
+    ExceptionFilter,
+    Catch,
+    ArgumentsHost,
+    HttpException,
+    HttpStatus,
+    ForbiddenException,
+} from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { BusinessException, PreviousProblemUnsolvedExeption } from './errors';
+
+@Catch()
+export class LastExceptionFilter implements ExceptionFilter {
+    constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+    catch(exception: unknown, host: ArgumentsHost) {
+        const { httpAdapter } = this.httpAdapterHost;
+
+        const ctx = host.switchToHttp();
+
+        const httpStatus =
+            exception instanceof HttpException
+                ? exception.getStatus()
+                : HttpStatus.INTERNAL_SERVER_ERROR;
+
+        const responseBody = {
+            statusCode: httpStatus,
+            timestamp: new Date().toISOString(),
+            path: httpAdapter.getRequestUrl(ctx.getRequest()),
+        };
+
+        httpAdapter.reply(ctx.getResponse(), responseBody, httpStatus);
+    }
+}
+
+@Catch(BusinessException)
+export class BusinessExceptionsFilter extends LastExceptionFilter {
+    catch(exception: unknown, host: ArgumentsHost) {
+        // 이해를 돕기 위한 샘플로 만들었음. 필요없으면 삭제 가능
+        if (exception instanceof PreviousProblemUnsolvedExeption) {
+          super.catch(new ForbiddenException(exception), host);
+          return;
+        }
+        super.catch(exception, host);
+    }
+}

--- a/backend/src/common/logger/config.ts
+++ b/backend/src/common/logger/config.ts
@@ -1,0 +1,22 @@
+import { utilities as nestWinstonModuleUtilities } from 'nest-winston';
+import * as winston from 'winston';
+
+const winstonConfig = {
+    transports: [
+        new winston.transports.Console({
+            level: 'debug',
+            format: winston.format.combine(
+                winston.format.timestamp({
+                    format: 'YYYY-MM-DD HH:mm:ss',
+                }),
+                winston.format.ms(),
+                nestWinstonModuleUtilities.format.nestLike('SandBoxProxy', {
+                    prettyPrint: true,
+                    colors: true,
+                })
+            ),
+        }),
+    ],
+};
+
+export { winstonConfig };

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { winstonConfig } from './common/logger/config';
+import { WinstonModule } from 'nest-winston';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+    const app = await NestFactory.create(AppModule, {
+        logger: WinstonModule.createLogger(winstonConfig),
+        bufferLogs: true,
+    });
+    await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './user.entity';
 import { Repository } from 'typeorm';
+import { PreviousProblemUnsolvedExeption } from 'src/common/exception/errors';
 
 @Controller('users')
 export class UsersController {
@@ -11,7 +12,9 @@ export class UsersController {
     ) {}
 
     @Get()
-    findAll(): Promise<User[]> {
-        return this.usersRepository.find();
+    findAll() {
+        // 이해를 돕기 위한 샘플로 만들었음. 필요없으면 삭제 가능
+        throw new PreviousProblemUnsolvedExeption();
+        return this.usersRepository.findOneByOrFail({firstName: '123'});
     }
 }


### PR DESCRIPTION
## 작업 개요

closes #166 

nestjs에 예외 처리를 위한 exception filter를 추가한다.
추가로, winston 로거를 설정한다.

## 작업 상세 내용

https://www.notion.so/sehwan-park/Nestjs-Exception-Filter-Winston-13bc89eb183c803593c9e05431f9d4ef?pvs=4

<img width="615" alt="image" src="https://github.com/user-attachments/assets/3c3d6ebc-e453-4ff7-b920-a1def9f416ca">

### 주의할 점
exception filter를 등록하는 순서가 중요합니다. 우선도가 높은 exception filter를 나중에 등록해야 합니다.
filter A와 filter B에 모두 잡히는 에러가 있을 때, filter A에서 해당 에러를 처리하고 싶으면 filter B, filter A 순으로 등록해야 한다는 의미입니다.
본 PR에서는 BusinessExceptionFIlter를 나중에 등록했습니다. (app.module.ts 참고)

## 참고자료(선택)

## 문제점 혹은 고민(선택)