### PR TITLE
image 가져오기 페이지 문제 내용 및 시각화 데이터 요청

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 import LandingPage from './components/LandingPage';
 import ImagePullPage from './components/ImagePullPage';
+import ErrorPage from './components/ErrorPage';
 import { Routes, Route } from 'react-router-dom';
 
 const App = () => {
@@ -13,6 +14,7 @@ const App = () => {
                 <Routes>
                     <Route path='/' element={<LandingPage />} />
                     <Route path='/image/quiz/1' element={<ImagePullPage />} />
+                    <Route path='/error/:id' element={<ErrorPage />} />
                 </Routes>
             </div>
         </>

--- a/frontend/src/api/quiz.ts
+++ b/frontend/src/api/quiz.ts
@@ -1,0 +1,48 @@
+import { Quiz, Visualization } from '../types/quiz';
+import axios from 'axios';
+import { NavigateFunction } from 'react-router-dom';
+
+const handleErrorResponse = (error: unknown, navigate: NavigateFunction) => {
+    if (axios.isAxiosError(error)) {
+        if (error.response) {
+            navigate(`/error/${error.response.status}`);
+        } else if (error.request) {
+            console.error('요청이 전송되었지만, 응답이 수신되지 않았습니다: ', error.request);
+        } else {
+            console.error(
+                '오류가 발생한 요청을 설정하는 동안 문제가 발생했습니다: ',
+                error.message
+            );
+        }
+    } else {
+        console.error('unknown error');
+    }
+};
+
+export const requestQuizData = (
+    setQuizData: React.Dispatch<React.SetStateAction<Quiz | null>>,
+    navigate: NavigateFunction
+) => {
+    axios
+        .get('http://localhost:3000/quiz/1')
+        .then((response) => {
+            setQuizData(response.data);
+        })
+        .catch((error) => {
+            handleErrorResponse(error, navigate);
+        });
+};
+
+export const requestVisualizationData = (
+    setVisualizationData: React.Dispatch<React.SetStateAction<Visualization | null>>,
+    navigate: NavigateFunction
+) => {
+    axios
+        .get('http://localhost:3000/sandbox/elements')
+        .then((response) => {
+            setVisualizationData(response.data);
+        })
+        .catch((error) => {
+            handleErrorResponse(error, navigate);
+        });
+};

--- a/frontend/src/components/ErrorPage.tsx
+++ b/frontend/src/components/ErrorPage.tsx
@@ -1,0 +1,24 @@
+import { useParams } from 'react-router-dom';
+
+const ErrorPage = () => {
+    const { id } = useParams();
+    const statusCode = id ? parseInt(id) : null;
+
+    const errorMessages: Record<number, string> = {
+        403: 'Forbidden',
+        404: 'Page not found',
+        500: 'Internal server error',
+    };
+
+    const message =
+        statusCode && statusCode in errorMessages ? errorMessages[statusCode] : 'Unhandled error';
+
+    return (
+        <div className='w-full flex flex-col items-center justify-start font-pretendard'>
+            <h1 className='font-bold text-5xl text-gray-950'>{id}</h1>
+            <p className='font-medium text-2xl text-gray-700'>{message}</p>
+        </div>
+    );
+};
+
+export default ErrorPage;

--- a/frontend/src/components/ImagePullPage.tsx
+++ b/frontend/src/components/ImagePullPage.tsx
@@ -2,8 +2,8 @@ const ImagePullPage = () => {
     return (
         <div className='font-pretendard w-[calc(100vw-17rem)] p-4'>
             <h1 className='font-bold text-3xl text-Dark-Blue mb-3'>image 가져오기</h1>
-            <section className='flex flex-row h-1/2'>
-                <div className='flex flex-col w-[33%] border rounded-lg border-gray-300 my-4 ml-4 mr-1 pl-4'>
+            <section className='flex h-1/2'>
+                <div className='w-[33%] border rounded-lg border-gray-300 my-4 ml-4 mr-1 pl-4'>
                     <h2 className='font-semibold text-2xl text-Dark-Blue pt-4 pb-2'>문제</h2>
                     <p className='font-medium text-lg text-gray-800'>
                         이미지를 가져오는 docker 명령어를 입력하세요. <br />

--- a/frontend/src/components/ImagePullPage.tsx
+++ b/frontend/src/components/ImagePullPage.tsx
@@ -7,12 +7,31 @@ const ImagePullPage = () => {
     const navigate = useNavigate();
     const [quizData, setQuizData] = useState<Quiz | null>(null);
     const [visualizationData, setVisualizationData] = useState<Visualization | null>(null);
+    const [terminalInput, setTerminalInput] = useState<string>('~$ ');
 
     useEffect(() => {
         requestQuizData(setQuizData, navigate);
         requestVisualizationData(setVisualizationData, navigate);
         console.log(visualizationData); // lint error를 해결하기 위한 임시 코드
     }, []);
+
+    const handleTerminalInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const value = event.target.value;
+        const prefix = '~$ ';
+
+        if (value.startsWith(prefix)) {
+            setTerminalInput(value);
+        } else {
+            const userInput = value.slice(prefix.length);
+            setTerminalInput(prefix + userInput);
+        }
+    };
+
+    const handleTerminalEnter = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (event.key === 'Enter') {
+            console.log('Enter key pressed');
+        }
+    };
 
     return (
         <div className='font-pretendard w-[calc(100vw-17rem)] p-4'>
@@ -27,7 +46,12 @@ const ImagePullPage = () => {
                 <div className='w-[50%] border rounded-lg border-gray-300 my-4 ml-1'></div>
             </section>
             <section className='h-[30%] w-[83.5%] border rounded-lg border-gray-300 bg-gray-50 ml-4'>
-                명령어 입력창
+                <textarea
+                    value={terminalInput}
+                    onChange={handleTerminalInput}
+                    onKeyDown={handleTerminalEnter}
+                    className='w-full h-full text-gray-700 rounded-lg bg-inherit resize-none focus:outline-none p-2'
+                ></textarea>
             </section>
             <section className='w-[85%] flex justify-end'>
                 <button className='text-lg text-white rounded-lg bg-gray-400 hover:bg-gray-500 py-2 px-4 my-4 mx-1'>

--- a/frontend/src/components/ImagePullPage.tsx
+++ b/frontend/src/components/ImagePullPage.tsx
@@ -1,43 +1,17 @@
 import { useEffect, useState } from 'react';
-import axios from 'axios';
-import { useNavigate, NavigateFunction } from 'react-router-dom';
-
-interface Quiz {
-    id: number;
-    title: string;
-    content: string;
-}
-
-const handleErrorResponse = (error: unknown, navigate: NavigateFunction) => {
-    if (axios.isAxiosError(error)) {
-        if (error.response) {
-            navigate(`/error/${error.response.status}`);
-        } else if (error.request) {
-            console.error('요청이 전송되었지만, 응답이 수신되지 않았습니다: ', error.request);
-        } else {
-            console.error(
-                '오류가 발생한 요청을 설정하는 동안 문제가 발생했습니다: ',
-                error.message
-            );
-        }
-    } else {
-        console.error('unknown error');
-    }
-};
+import { useNavigate } from 'react-router-dom';
+import { Quiz, Visualization } from '../types/quiz';
+import { requestQuizData, requestVisualizationData } from '../api/quiz';
 
 const ImagePullPage = () => {
     const navigate = useNavigate();
     const [quizData, setQuizData] = useState<Quiz | null>(null);
+    const [visualizationData, setVisualizationData] = useState<Visualization | null>(null);
 
     useEffect(() => {
-        axios
-            .get('http://localhost:3000/quiz/1')
-            .then((response) => {
-                setQuizData(response.data);
-            })
-            .catch((error) => {
-                handleErrorResponse(error, navigate);
-            });
+        requestQuizData(setQuizData, navigate);
+        requestVisualizationData(setVisualizationData, navigate);
+        console.log(visualizationData); // lint error를 해결하기 위한 임시 코드
     }, []);
 
     return (

--- a/frontend/src/components/ImagePullPage.tsx
+++ b/frontend/src/components/ImagePullPage.tsx
@@ -1,15 +1,53 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useNavigate, NavigateFunction } from 'react-router-dom';
+
+interface Quiz {
+    id: number;
+    title: string;
+    content: string;
+}
+
+const handleErrorResponse = (error: unknown, navigate: NavigateFunction) => {
+    if (axios.isAxiosError(error)) {
+        if (error.response) {
+            navigate(`/error/${error.response.status}`);
+        } else if (error.request) {
+            console.error('요청이 전송되었지만, 응답이 수신되지 않았습니다: ', error.request);
+        } else {
+            console.error(
+                '오류가 발생한 요청을 설정하는 동안 문제가 발생했습니다: ',
+                error.message
+            );
+        }
+    } else {
+        console.error('unknown error');
+    }
+};
+
 const ImagePullPage = () => {
+    const navigate = useNavigate();
+    const [quizData, setQuizData] = useState<Quiz | null>(null);
+
+    useEffect(() => {
+        axios
+            .get('http://localhost:3000/quiz/1')
+            .then((response) => {
+                setQuizData(response.data);
+            })
+            .catch((error) => {
+                handleErrorResponse(error, navigate);
+            });
+    }, []);
+
     return (
         <div className='font-pretendard w-[calc(100vw-17rem)] p-4'>
             <h1 className='font-bold text-3xl text-Dark-Blue mb-3'>image 가져오기</h1>
             <section className='flex h-1/2'>
                 <div className='w-[33%] border rounded-lg border-gray-300 my-4 ml-4 mr-1 pl-4'>
                     <h2 className='font-semibold text-2xl text-Dark-Blue pt-4 pb-2'>문제</h2>
-                    <p className='font-medium text-lg text-gray-800'>
-                        이미지를 가져오는 docker 명령어를 입력하세요. <br />
-                        지원하는 이미지는 다음과 같습니다. <br />
-                        hello-world <br />
-                        nginx <br />
+                    <p className='font-medium text-lg text-gray-800 whitespace-pre-wrap'>
+                        {quizData?.content}
                     </p>
                 </div>
                 <div className='w-[50%] border rounded-lg border-gray-300 my-4 ml-1'></div>

--- a/frontend/src/types/quiz.ts
+++ b/frontend/src/types/quiz.ts
@@ -1,0 +1,22 @@
+export type Quiz = {
+    id: number;
+    title: string;
+    content: string;
+};
+
+export type Visualization = {
+    containers: Container[];
+    images: Image[];
+};
+
+export type Container = {
+    id: string;
+    imageId: string;
+    status: string;
+    name: string;
+};
+
+export type Image = {
+    id: string;
+    name: string;
+};


### PR DESCRIPTION
## 작업 개요

- #14 
- #15 
- #17 

## 작업 상세 내용

- [x] 이미지 가져오기 페이지 컴포넌트가 mount될 때 문제 데이터 요청
  - [x] useEffect() 훅 사용
  - [x] 응답으로 받은 문제 데이터 렌더링
- [x] 상태코드가 4xx, 5xx 번대인 경우 에러 페이지 렌더링
  - [x] 403, 404, 500 응답에 대한 에러 메시지 출력
- [x] 도커 환경 가시화 데이터 요청 기능 구현
  - [x] Container와 Image에 대한 임시 타입 정의
- [x] 명령어 입력창 기본 레이아웃 구현
  - [x] textarea 추가

[개발 일지](https://github.com/boostcampwm-2024/web34-LearnDocker/wiki/%5B3%EC%A3%BC-2%EC%9D%BC%EC%B0%A8-%E2%80%90-J034-%EA%B9%80%EB%91%90%EC%A2%85%5D-%EA%B0%9C%EB%B0%9C-%EC%9D%BC%EC%A7%80)

### 결과 403 페이지

![403-forbidde2](https://github.com/user-attachments/assets/f770c3e2-6076-45e2-ab71-ef7d511de375)

### 


## 참고자료(선택)

[axios 에러 핸들링](https://axios-http.com/kr/docs/handling_errors)

## 문제점 혹은 고민(선택)

### 새로 고침시 404 에러가 발생하는 문제

- react가 기본적으로 SPA로 동작하는데, react-router-dom으로 url을 변경해주는 작업을 하다보니 새로고침을 하게 되면 서버에 루트 경로(/)가 아닌 react-router로 설정한 경로로 요청이 가게 됩니다.
- 그러면 당연히 서버에서는 해당 위치의 파일을 찾을 수 없기 때문에 404 not found를 응답으로 보내주는 것 같습니다.
- 서버에서 기본적으로 모든 요청을 루트 경로(/)로 설정해주고, api 요청 경로를 따로 설정해서 이 부분만 별도로 처리해주는 로직이 필요해 보입니다. (/api/*)

![refresh-error](https://github.com/user-attachments/assets/7432d4fd-b8d1-4851-a193-40c607faf24b)


