### PR TITLE
시각화 뼈대 완성 및 이미지 관련 상태 변화 시각화 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.7",
+    "lucide-react": "^0.456.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0"

--- a/frontend/src/components/BaseNode.tsx
+++ b/frontend/src/components/BaseNode.tsx
@@ -1,0 +1,16 @@
+import { NodeProps } from '../types/types';
+
+export const BaseNode = ({ label, icon: Icon, gridRow, gridColumn }: NodeProps) => {
+    return (
+        <div
+            className='flex flex-col items-center gap-1'
+            style={{
+                gridRowStart: gridRow,
+                gridColumnStart: gridColumn,
+            }}
+        >
+            <span className='text-sm'>{label}</span>
+            <Icon size={64} />
+        </div>
+    );
+};

--- a/frontend/src/components/ContainerNode.tsx
+++ b/frontend/src/components/ContainerNode.tsx
@@ -1,0 +1,39 @@
+import { ContainerNodeProps } from '../types/types';
+
+const ContainerNode = ({
+    label,
+    icon: Icon,
+    gridRow,
+    gridColumn,
+    containerData,
+}: ContainerNodeProps) => {
+    return (
+        <div
+            className='border-gray-300 border-2 relative flex flex-col'
+            style={{
+                gridRowStart: gridRow,
+                gridColumnStart: gridColumn,
+            }}
+        >
+            <div className='absolute -top-20 -left-8 flex flex-col items-start gap-2'>
+                <span className='text-sm'>{label}</span>
+                <Icon size={64} />
+            </div>
+            <div className='flex flex-col overflow-auto'>
+                {containerData.map(({ id, name, color }) => (
+                    <div
+                        className='border-4 rounded m-1 text-xs'
+                        style={{
+                            borderColor: color,
+                        }}
+                        key={id}
+                    >
+                        {name}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default ContainerNode;

--- a/frontend/src/components/DockerVisualization.tsx
+++ b/frontend/src/components/DockerVisualization.tsx
@@ -1,0 +1,60 @@
+import { Laptop, Server, Container, Database, Cloud } from 'lucide-react';
+import { BaseNode } from './BaseNode';
+import ContainerNode from './ContainerNode';
+import { DockerPullVisualizationProps } from '../types/types';
+
+const DockerPullVisualization = ({ containers, images }: DockerPullVisualizationProps) => {
+    const initBaseNodes = [
+        {
+            label: 'client',
+            icon: Laptop,
+            gridColumn: 1,
+            gridRow: 3,
+        },
+        {
+            label: 'docker engine',
+            icon: Server,
+            gridColumn: 2,
+            gridRow: 3,
+        },
+
+        {
+            label: 'registry',
+            icon: Cloud,
+            gridColumn: 5,
+            gridRow: 4,
+        },
+    ];
+
+    return (
+        <div className='grid grid-cols-5 grid-rows-5 w-[50%] border rounded-lg border-gray-300 my-4 ml-1'>
+            {initBaseNodes.map(({ label, icon, gridRow, gridColumn }) => (
+                <BaseNode
+                    key={label}
+                    label={label}
+                    icon={icon}
+                    gridColumn={gridColumn}
+                    gridRow={gridRow}
+                />
+            ))}
+            <ContainerNode
+                key='containers'
+                label='containers'
+                icon={Container}
+                gridRow={2}
+                gridColumn={4}
+                containerData={containers}
+            />
+            <ContainerNode
+                key='images'
+                label='images'
+                icon={Database}
+                gridRow={4}
+                gridColumn={4}
+                containerData={images}
+            />
+        </div>
+    );
+};
+
+export default DockerPullVisualization;

--- a/frontend/src/components/ImagePullPage.tsx
+++ b/frontend/src/components/ImagePullPage.tsx
@@ -1,4 +1,49 @@
+import { useState } from 'react';
+import axios from 'axios';
+import DockerVisualization from './DockerVisualization';
+import { Image, Container } from '../types/types';
+
+const updateImageColors = (newImages: Image[], prevImages: Image[]) => {
+    const colors = ['#FF6B6B', '#FFC107', '#4CAF50', '#2196F3', '#673AB7', '#E91E63'];
+
+    const updatedImages = newImages.map((newImage, index) => {
+        const prevImage = prevImages.find((img) => img.id === newImage.id);
+        if (prevImage) {
+            return prevImage;
+        }
+
+        return {
+            ...newImage,
+            // 이미지가 항상 순서대로 들어온다는 가정
+            color: colors[index % colors.length],
+        };
+    });
+
+    const isUpdated = updatedImages.length !== prevImages.length;
+
+    return { updatedImages, isUpdated };
+};
+
 const ImagePullPage = () => {
+    const [images, setImages] = useState<Image[]>([]);
+    // TODO: container 관련 상태 시각화 아직 못함
+    const [containers, setContainers] = useState<Container[]>([]);
+
+    // TODO: handleClick은 테스트 용도
+    // 1. 나중에 명령창에서 엔터를 눌렀을때로 변경해야함
+    // 2. url 변경 및 axios 반환 값(백엔드 api 명세서 보고) 수정 필요
+    const handleClick = async () => {
+        const newImages: Image[] = (
+            await axios({ method: 'get', url: 'http://localhost:8080/visualization/images' })
+        ).data;
+
+        const { updatedImages, isUpdated } = updateImageColors(newImages, images);
+
+        if (isUpdated) {
+            setImages(updatedImages);
+        }
+    };
+
     return (
         <div className='font-pretendard w-[calc(100vw-17rem)] p-4'>
             <h1 className='font-bold text-3xl text-Dark-Blue mb-3'>image 가져오기</h1>
@@ -12,10 +57,17 @@ const ImagePullPage = () => {
                         nginx <br />
                     </p>
                 </div>
-                <div className='w-[50%] border rounded-lg border-gray-300 my-4 ml-1'></div>
+                <DockerVisualization images={images} containers={containers} />
             </section>
             <section className='h-[30%] w-[83.5%] border rounded-lg border-gray-300 bg-gray-50 ml-4'>
                 명령어 입력창
+                {/* TODO: 테스트 용도 onClick */}
+                <button
+                    onClick={handleClick}
+                    className='text-xl text-white rounded-lg bg-Moby-Blue hover:bg-blue-800 py-2 px-4 m-4'
+                >
+                    test 용도
+                </button>
             </section>
             <section className='w-[85%] flex justify-end'>
                 <button className='text-lg text-white rounded-lg bg-gray-400 hover:bg-gray-500 py-2 px-4 my-4 mx-1'>

--- a/frontend/src/components/ImagePullPage.tsx
+++ b/frontend/src/components/ImagePullPage.tsx
@@ -19,9 +19,7 @@ const updateImageColors = (newImages: Image[], prevImages: Image[]) => {
         };
     });
 
-    const isUpdated = updatedImages.length !== prevImages.length;
-
-    return { updatedImages, isUpdated };
+    return updatedImages;
 };
 
 const ImagePullPage = () => {
@@ -37,11 +35,12 @@ const ImagePullPage = () => {
             await axios({ method: 'get', url: 'http://localhost:8080/visualization/images' })
         ).data;
 
-        const { updatedImages, isUpdated } = updateImageColors(newImages, images);
-
-        if (isUpdated) {
-            setImages(updatedImages);
+        if (images.length === newImages.length) {
+            return;
         }
+        const updatedImages = updateImageColors(newImages, images);
+
+        setImages(updatedImages);
     };
 
     return (

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import dropDownImage from '../assets/dropDown.svg';
 import StartButton from './StartButton';
 import { Link } from 'react-router-dom';
+import { SidebarSectionProps } from '../types/types';
 
 const links = [
     { title: 'Home', path: '/' },
@@ -25,14 +26,6 @@ const dockerContainerLinks = [
     { title: 'Container 중지하기', path: '/container/quiz/5' },
     { title: 'Container 삭제하기', path: '/container/quiz/6' },
 ];
-
-type SidebarSectionProps = {
-    title: string;
-    links: Array<{
-        title: string;
-        path: string;
-    }>;
-};
 
 const SidebarSection = ({ title, links }: SidebarSectionProps) => {
     const [isOpen, setIsOpen] = useState(true);

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -1,0 +1,44 @@
+import { LucideIcon } from 'lucide-react';
+
+export type Image = {
+    id: string;
+    name: string;
+    color?: string;
+};
+
+export type Container = {
+    id: string;
+    name: string;
+    imageId: string;
+    // TODO: status는 나중에 type으로 지정해도 좋을 듯(백엔드랑 협의 필요)
+    status: string;
+    color?: string;
+};
+
+export type NodeProps = {
+    label: string;
+    icon: LucideIcon;
+    gridColumn: number;
+    gridRow: number;
+};
+
+export type ContainerNodeProps = {
+    label: string;
+    icon: LucideIcon;
+    gridColumn: number;
+    gridRow: number;
+    containerData: Image[] | Container[];
+};
+
+export type SidebarSectionProps = {
+    title: string;
+    links: Array<{
+        title: string;
+        path: string;
+    }>;
+};
+
+export type DockerPullVisualizationProps = {
+    containers: Container[];
+    images: Image[];
+};


### PR DESCRIPTION
## 작업 개요
- #20 
- 시각화 뼈대 및 이미지 관련 상태 변화 시각화 구현
- 이미지 관련 명령어 흐름, 컨테이너 상태 변화 시각화, 명령어 흐름은 아직 구현 못함
![이미지상태시각화예시](https://github.com/user-attachments/assets/f7a6c63d-e6be-49e7-a32f-7890d27811dd)

## 작업 상세 내용
- [x]  시각화 뼈대 그리기
    - [x]  lucid-react로 아이콘 받아오기
    - [x]  피그마에서 정한 뼈대 구현
        - [x]  컴포넌트를 어떻게 나눌 것인지 결정
        - [x]  레이아웃을 어떻게 할 것인지 결정
- [ ]  이미지 시각화
    - [x]  이미지 변화에 따른 상태 시각화(useState 활용)
        - [x]  이미지가 추가 되면 images 안에 이미지 div 추가
            - [x]  고유의 색상을 가지고 있어야 함
        - [x]  이미지가 삭제 되면 해당하는 이미지 div 삭제
    - [ ]  이미지 변화에 따른 흐름 시각화
      - [ ]  애니매이션을 순서대로 실행 하려면 어떻게 하는지 알아보기
      - [ ]  이미지가 추가 되면(client -> docker api -> images -> repositry -> images) 순으로 흐름을 보여줘야 함
      - [ ]  이미지가 삭제 되면(client -> docker api -> images) 순으로 흐름을 보여줘야 함

## 문제점 혹은 고민
https://github.com/boostcampwm-2024/web34-LearnDocker/wiki/%5B3%EC%A3%BC-2%EC%9D%BC%EC%B0%A8---J278-%ED%99%8D%EA%B7%9C%EC%84%A0%5D-%EA%B0%9C%EB%B0%9C-%EC%9D%BC%EC%A7%80%28%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%83%81%ED%83%9C-%EC%8B%9C%EA%B0%81%ED%99%94-%EA%B5%AC%ED%98%84%29