### PR TITLE
axios api 요청 async/await 방식으로 변경

### DIFF
--- a/frontend/src/api/quiz.ts
+++ b/frontend/src/api/quiz.ts
@@ -1,4 +1,5 @@
-import { Quiz, Visualization } from '../types/quiz';
+import { Quiz, QuizResult } from '../types/quiz';
+import { Visualization } from '../types/visualization';
 import axios from 'axios';
 import { NavigateFunction } from 'react-router-dom';
 
@@ -20,92 +21,66 @@ const handleErrorResponse = (error: unknown, navigate: NavigateFunction) => {
     } else {
         console.error('unknown error');
     }
+    return null;
 };
 
-export const requestQuizData = (
-    setQuizData: React.Dispatch<React.SetStateAction<Quiz | null>>,
-    navigate: NavigateFunction
-) => {
-    axios
-        .get(`http://${PROXY_HOST}:${PROXY_PORT}/api/quiz/1`)
-        .then((response) => {
-            setQuizData(response.data);
-        })
-        .catch((error) => {
-            handleErrorResponse(error, navigate);
-        });
+export const requestQuizData = async (navigate: NavigateFunction) => {
+    try {
+        const response = await axios.get<Quiz>(`http://${PROXY_HOST}:${PROXY_PORT}/api/quiz/1`);
+        return response.data;
+    } catch (error) {
+        return handleErrorResponse(error, navigate);
+    }
 };
 
-export const requestVisualizationData = (
-    callback: (data: Visualization) => void,
-    navigate: NavigateFunction
-) => {
-    axios
-        .get(`http://${PROXY_HOST}:${PROXY_PORT}/api/sandbox/elements`)
-        .then((response) => {
-            callback(response.data);
-        })
-        .catch((error) => {
-            handleErrorResponse(error, navigate);
-        });
+export const requestVisualizationData = async (navigate: NavigateFunction) => {
+    try {
+        const response = await axios.get<Visualization>(
+            `http://${PROXY_HOST}:${PROXY_PORT}/api/sandbox/elements`
+        );
+        return response.data;
+    } catch (error) {
+        return handleErrorResponse(error, navigate);
+    }
 };
 
-export const createHostContainer = (
-    setLoading: React.Dispatch<React.SetStateAction<boolean>>,
-    navigate: NavigateFunction
-) => {
-    axios
-        .post(`http://${PROXY_HOST}:${PROXY_PORT}/api/sandbox/start`)
-        .then(() => {
-            setLoading(false);
-        })
-        .catch((error) => {
-            handleErrorResponse(error, navigate);
-        });
+export const createHostContainer = async (navigate: NavigateFunction) => {
+    try {
+        await axios.post(`http://${PROXY_HOST}:${PROXY_PORT}/api/sandbox/start`);
+        return true;
+    } catch (error) {
+        return handleErrorResponse(error, navigate);
+    }
 };
 
-export const reqeustSubmitResult = (
-    setSubmitResult: React.Dispatch<React.SetStateAction<string>>,
-    navigate: NavigateFunction
-) => {
-    axios
-        .post(`http://${PROXY_HOST}:${PROXY_PORT}/api/quiz/1/submit`)
-        .then((response) => {
-            // TODO: 백엔드와 협의하여 응답 데이터 구조를 정의해야 한다.
-            // 현재는 { quizResult: 'SUCCESS' | 'FAIL' | 'ERROR' }로 가정
-            // console.log는 테스트 용도, 나중에 삭제해야 함
-            const result = response.data;
-            console.log(result);
-
-            if (result?.quizResult === 'SUCCESS') {
-                setSubmitResult('SUCCESS');
-            } else if (result?.quizResult === 'FAIL') {
-                setSubmitResult('FAIL');
-            } else {
-                setSubmitResult('ERROR');
-            }
-        })
-        .catch((error) => {
-            handleErrorResponse(error, navigate);
-        });
+export const requestSubmitResult = async (navigate: NavigateFunction) => {
+    try {
+        const response = await axios.post<QuizResult>(
+            `http://${PROXY_HOST}:${PROXY_PORT}/api/quiz/1/submit`
+        );
+        return response.data;
+    } catch (error) {
+        return handleErrorResponse(error, navigate);
+    }
 };
 
-export const requestCommandResult = (
+export const requestCommandResult = async (
     command: string,
-    callback: (data: string) => void,
     navigate: NavigateFunction,
     customErrorCallback?: (error: unknown) => void
 ) => {
-    axios
-        .post(`http://${PROXY_HOST}:${PROXY_PORT}/api/sandbox/command`, { command })
-        .then((response) => {
-            callback(response.data);
-        })
-        .catch((error) => {
-            if (customErrorCallback !== undefined) {
-                customErrorCallback(error);
-            } else {
-                handleErrorResponse(error, navigate);
-            }
-        });
+    try {
+        const response = await axios.post<string>(
+            `http://${PROXY_HOST}:${PROXY_PORT}/api/sandbox/command`,
+            { command }
+        );
+        return response.data;
+    } catch (error) {
+        if (customErrorCallback !== undefined) {
+            customErrorCallback(error);
+        } else {
+            handleErrorResponse(error, navigate);
+        }
+        return null;
+    }
 };

--- a/frontend/src/components/ImagePullPage.tsx
+++ b/frontend/src/components/ImagePullPage.tsx
@@ -15,7 +15,17 @@ const ImagePullPage = () => {
         useDockerVisualization();
 
     useEffect(() => {
-        requestQuizData(setQuizData, navigate);
+        const fetchQuizData = async () => {
+            const data = await requestQuizData(navigate);
+
+            if (!data) {
+                return;
+            }
+
+            setQuizData(data);
+        };
+
+        fetchQuizData();
     }, [navigate]);
 
     return (

--- a/frontend/src/components/StartButton.tsx
+++ b/frontend/src/components/StartButton.tsx
@@ -9,7 +9,10 @@ const StartButton = () => {
 
     const handleButtonClick = async () => {
         setLoading(true);
-        await createHostContainer(setLoading, navigate);
+        const success =  await createHostContainer(navigate);
+        if (success) {
+            setLoading(false);
+        }
     };
 
     return (

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -1,13 +1,22 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { reqeustSubmitResult } from '../../api/quiz';
+import { requestSubmitResult } from '../../api/quiz';
 
 const QuizButtons = () => {
     const [submitResult, setSubmitResult] = useState('default');
     const navigate = useNavigate();
 
-    const handleSubmitButtonClick = () => {
-        reqeustSubmitResult(setSubmitResult, navigate);
+    const handleSubmitButtonClick = async () => {
+        const submitResponse = await requestSubmitResult(navigate);
+        if (!submitResponse) {
+            return;
+        }
+
+        if (submitResponse.quizResult === 'SUCCESS') {
+            setSubmitResult('SUCCESS');
+        } else {
+            setSubmitResult('FAIL');
+        }
 
         // TODO: submitResult의 상태에 따라 모달창을 띄워줘야 한다.
         // 아래 console.log는 테스트 용도, 나중에 삭제해야 함

--- a/frontend/src/hooks/useDockerVisualization.ts
+++ b/frontend/src/hooks/useDockerVisualization.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { requestVisualizationData } from '../api/quiz';
 import { Image, DOCKER_OPERATIONS, AnimationState, DockerOperation } from '../types/visualization';
 import { useNavigate } from 'react-router-dom';
-import { Visualization } from '../types/quiz';
+import { Visualization } from '../types/visualization';
 
 const useDockerVisualization = () => {
     const navigate = useNavigate();
@@ -59,9 +59,15 @@ const useDockerVisualization = () => {
         setDockerOperation(operation);
     };
 
-    const updateVisualizationData = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const updateVisualizationData = async (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (event.key === 'Enter') {
-            requestVisualizationData(handleTerminalEnterCallback, navigate);
+            const data = await requestVisualizationData(navigate);
+
+            if (!data) {
+                return;
+            }
+
+            handleTerminalEnterCallback(data);
         }
     };
 

--- a/frontend/src/hooks/useTerminalInput.ts
+++ b/frontend/src/hooks/useTerminalInput.ts
@@ -32,7 +32,7 @@ export const useTerminalInput = (): UseTerminalInput => {
         alert('허용되지 않은 명령어 입니다.');
     };
 
-    const handleTerminalEnter = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const handleTerminalEnter = async (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (event.key === 'Enter') {
             event.preventDefault();
 
@@ -40,9 +40,21 @@ export const useTerminalInput = (): UseTerminalInput => {
             const lastLine = lines[lines.length - 1];
             const command = lastLine?.slice(prefix.length).trim();
 
-            if (command) {
-                requestCommandResult(command, handleCommandSuccess, navigate, handleCommandError);
+            if (!command) {
+                return;
             }
+
+            const commandResponse = await requestCommandResult(
+                command,
+                navigate,
+                handleCommandError
+            );
+
+            if (!commandResponse) {
+                return;
+            }
+
+            handleCommandSuccess(commandResponse);
         }
     };
 

--- a/frontend/src/types/quiz.ts
+++ b/frontend/src/types/quiz.ts
@@ -4,21 +4,8 @@ export type Quiz = {
     content: string | undefined;
 };
 
-export type Visualization = {
-    containers: Container[];
-    images: Image[];
-};
-
-export type Container = {
-    id: string;
-    imageId: string;
-    status: string;
-    name: string;
-};
-
-export type Image = {
-    id: string;
-    name: string;
+export type QuizResult = {
+    quizResult: 'SUCCESS' | 'FAIL';
 };
 
 export type QuizTextAreaProps = {

--- a/frontend/src/types/visualization.ts
+++ b/frontend/src/types/visualization.ts
@@ -1,5 +1,10 @@
 import { LucideIcon } from 'lucide-react';
 
+export type Visualization = {
+    containers: Container[];
+    images: Image[];
+};
+
 export type Image = {
     id: string;
     name: string;


### PR DESCRIPTION
## 작업 개요

- #184 

## 작업 상세 내용

- [x] async/await 방식으로 api 요청 코드 수정
- [x] handleErrorResponse 함수가 null을 반환하도록 수정
- [x] 타입 수정
  - [x] quiz.ts에서 불필요하게 중복된 타입 삭제 (Image, Container)
  - [x] QuizResponse 타입 추가
  - [x] Visualization 타입을 quiz.ts에서 visualization.ts로 이동 

## 문제점 혹은 고민

- 아직 명령창과 관련된 로직이 완벽하게 구현되지는 않았습니다.
- 이 부분을 해결하기 위한 고민이 필요해보입니다.
- 현재까지 로컬에서 mysql과 docker 환경을 구축하고 테스트해본 결과를 공유드립니다

[docker pull 1차 시도]

![docker-pull-1차시도](https://github.com/user-attachments/assets/f8d1eac0-f25b-4071-8cee-6dbd8dbe4077)

[docker pull 2차 시도]

![docker-pull-2차시도](https://github.com/user-attachments/assets/a1663079-2a91-4005-81e1-a96fd15cd590)

### 현재까지 파악된 문제점

- 명령창에서 엔터를 눌렀을 때 다음 행으로 넘어가면 앞에 prefix(=`~$`)가 사라짐
  - 일단 테스트할 때는 수동으로 작성했습니다
- docker 상태 확인 명령어들은 정상적으로 동작하는데, docker image pull 같은 명령은 처음에 거부되었다가, 다시 시도하면 정상적인 응답이 도착합니다.