### PR TITLE
배포 시 nestjs 서버에 로그를 파일로 남기기

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -34,7 +34,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.20",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "winston-daily-rotate-file": "^5.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Logger, Module } from '@nestjs/common';
+import { Logger, MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -8,8 +8,13 @@ import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import { SandboxModule } from './sandbox/sandbox.module';
 import { APP_FILTER } from '@nestjs/core';
-import { BusinessExceptionsFilter, HttpExceptionsFilter, LastExceptionFilter } from './common/exception/filters';
+import {
+    BusinessExceptionsFilter,
+    HttpExceptionsFilter,
+    LastExceptionFilter,
+} from './common/exception/filters';
 import { AuthModule } from './common/auth/auth.module';
+import { LoggerMiddleware } from './common/logger/middleware';
 
 @Module({
     imports: [
@@ -29,7 +34,7 @@ import { AuthModule } from './common/auth/auth.module';
         ServeStaticModule.forRoot({
             rootPath: join(__dirname, '..', '..', 'frontend', 'dist'),
             exclude: ['/api*'],
-            renderPath:'/*',
+            renderPath: '/*',
         }),
         AuthModule,
     ],
@@ -51,4 +56,8 @@ import { AuthModule } from './common/auth/auth.module';
         Logger,
     ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+    configure(consumer: MiddlewareConsumer) {
+        consumer.apply(LoggerMiddleware).forRoutes({ path: '*', method: RequestMethod.ALL });
+    }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,7 +8,7 @@ import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import { SandboxModule } from './sandbox/sandbox.module';
 import { APP_FILTER } from '@nestjs/core';
-import { BusinessExceptionsFilter, LastExceptionFilter } from './common/exception/filters';
+import { BusinessExceptionsFilter, HttpExceptionsFilter, LastExceptionFilter } from './common/exception/filters';
 import { AuthModule } from './common/auth/auth.module';
 
 @Module({
@@ -39,6 +39,10 @@ import { AuthModule } from './common/auth/auth.module';
         {
             provide: APP_FILTER,
             useClass: LastExceptionFilter,
+        },
+        {
+            provide: APP_FILTER,
+            useClass: HttpExceptionsFilter,
         },
         {
             provide: APP_FILTER,

--- a/backend/src/common/decorator/hide-in-production.decorator.ts
+++ b/backend/src/common/decorator/hide-in-production.decorator.ts
@@ -5,7 +5,7 @@ import { Injectable, CanActivate } from '@nestjs/common';
 class HideInProductionGuard implements CanActivate {
 
   canActivate(): boolean {
-    if (process.env.NODE_ENV === 'prod') {
+    if (process.env.NODE_ENV === 'production') {
         throw new ForbiddenException('This API is only available in development mode.');
     }
     return true;

--- a/backend/src/common/exception/filters.ts
+++ b/backend/src/common/exception/filters.ts
@@ -34,22 +34,23 @@ export class LastExceptionFilter implements ExceptionFilter {
         };
 
         if (this.constructor.name === 'LastExceptionFilter') {
-            if (exception instanceof HttpException) {
-                this.logger.log(exception);
-            } else {
-                this.logger.error(exception);
-            }
+            this.logger.error(exception);
         }
 
         httpAdapter.reply(ctx.getResponse(), responseBody, httpStatus);
     }
 }
 
+@Catch(HttpException)
+export class HttpExceptionsFilter extends LastExceptionFilter {
+    catch(exception: HttpException, host: ArgumentsHost) {
+        super.catch(exception, host);
+    }
+}
+
 @Catch(BusinessException)
 export class BusinessExceptionsFilter extends LastExceptionFilter {
     catch(exception: unknown, host: ArgumentsHost) {
-        this.logger.log(exception);
-
         if (exception instanceof SessionAlreadyAssignedException) {
             super.catch(new ForbiddenException(exception), host);
             return;

--- a/backend/src/common/logger/config.ts
+++ b/backend/src/common/logger/config.ts
@@ -1,22 +1,65 @@
-import { utilities as nestWinstonModuleUtilities } from 'nest-winston';
+import { utilities as nestWinstonModuleUtilities, WinstonModuleOptions } from 'nest-winston';
 import * as winston from 'winston';
+import DailyRotateFile from 'winston-daily-rotate-file';
 
-const winstonConfig = {
-    transports: [
-        new winston.transports.Console({
-            level: 'debug',
-            format: winston.format.combine(
-                winston.format.timestamp({
-                    format: 'YYYY-MM-DD HH:mm:ss',
-                }),
-                winston.format.ms(),
-                nestWinstonModuleUtilities.format.nestLike('SandBoxProxy', {
-                    prettyPrint: true,
-                    colors: true,
-                })
-            ),
-        }),
-    ],
+const productionFormat = winston.format.combine(
+    winston.format.timestamp({
+        format: 'YYYY-MM-DD HH:mm:ss',
+    }),
+    winston.format.ms(),
+    nestWinstonModuleUtilities.format.nestLike('SandBoxProxy', {
+        prettyPrint: true,
+        colors: false,
+    })
+);
+const developmentFormat = winston.format.combine(
+    winston.format.timestamp({
+        format: 'YYYY-MM-DD HH:mm:ss',
+    }),
+    winston.format.ms(),
+    nestWinstonModuleUtilities.format.nestLike('SandBoxProxy', {
+        prettyPrint: true,
+        colors: true,
+    })
+);
+
+const productionTransports = [
+    // Info 레벨 로그
+    new DailyRotateFile({
+        level: 'info',
+        dirname: 'logs/log',
+        filename: '%DATE%.log',
+        datePattern: 'YYYY-MM-DD',
+        zippedArchive: false,
+        maxSize: '20m',
+        frequency: '1d',
+        maxFiles: '14d',
+        format: productionFormat,
+    }),
+    // Error 레벨 로그
+    new DailyRotateFile({
+        level: 'error',
+        dirname: 'logs/error',
+        filename: '%DATE%.log',
+        datePattern: 'YYYY-MM-DD',
+        zippedArchive: false,
+        maxSize: '20m',
+        frequency: '1d',
+        maxFiles: '14d',
+        format: productionFormat,
+    }),
+];
+
+const developmentTransports = [
+    new winston.transports.Console({
+        level: 'debug',
+        format: developmentFormat,
+    }),
+];
+
+const winstonConfig: WinstonModuleOptions = {
+    transports:
+        process.env.NODE_ENV === 'production' ? productionTransports : developmentTransports,
 };
 
 export { winstonConfig };

--- a/backend/src/common/logger/middleware.ts
+++ b/backend/src/common/logger/middleware.ts
@@ -1,0 +1,25 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+    private readonly logger = new Logger();
+
+    use(req: Request, res: Response, next: NextFunction) {
+        const { ip, originalUrl, method, headers, body, cookies } = req;
+
+        this.logger.log(
+            `IP: ${ip}, URL: ${originalUrl}, Method: ${method}, ${JSON.stringify(
+                {
+                    headers,
+                    body,
+                    cookies,
+                },
+                null,
+                2
+            )}`
+        );
+
+        next();
+    }
+}

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -3,7 +3,7 @@ import { SandboxService } from './sandbox.service';
 import { CommandValidationPipe } from './pipes/command.pipe';
 import { Request, Response } from 'express';
 import { SESSION_DURATION } from '../common/constant';
-import { HideInProduction } from '../common/decorator/hide-in-prod.decorator';
+import { HideInProduction } from '../common/decorator/hide-in-production.decorator';
 
 @Controller('sandbox')
 export class SandboxController {

--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -98,6 +98,9 @@ export class SandboxService {
 
         const newSessionId = randomUUID();
         this.cacheService.set(newSessionId, { containerId, renew: false, startTime: new Date() });
+
+        this.logger.log(`Container Assigned: ${containerId}\t Session: ${newSessionId}`);
+
         return newSessionId;
     }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "## 프로젝트 개요 > 고래🐳와 함께 자신만의 Docker 환경에서 학습해볼까요?",
   "main": "index.js",
   "scripts": {
+    "start": "pnpm -F frontend build && pnpm -F backend start",
     "lint": "eslint . ",
     "prettier": "prettier --write ."
   },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
     "prettier": "^3.3.3",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.13.0"
-  },
-  "dependencies": {
-    "dotenv": "^16.4.5"
   }
 }


### PR DESCRIPTION
## 작업 개요

Closes #183 

winston-daily-rotate-file 패키지를 사용하여 NODE_ENV=production인 경우, info 및 error 레벨에 대해 로그를 파일로 남깁니다.

## 작업 상세 내용

- root package.json에서 `pnpm start` 하면 프론트엔드 빌드 및 백엔드 서버 시작이 자동으로 이루어짐
- src/common/logger/config.ts에서 rotate 설정 추가
  - 14일 지나면 로그 삭제
  - 파일 단위는 1일 or 20MB
  - 배포 환경에서만 파일로 남고, 개발 환경(NODE_ENV !== "production")인 경우엔 기존 방법과 동일하게 콘솔에 출력됨
- HTTP Request가 들어오면 info 레벨로 로그를 남기도록 수정
  - ip, method, url, headers, cookies, body가 기록됨
- 비즈니스 예외는 로깅 대상에서 제외
  - /api/quiz/999로 GET 요청 보냈을 때 EntityNotExistException 비즈니스 예외가 던져지는데, 이는 우리가 로그로 남겨 디버깅해야 하는 상황이 아니라고 판단, 불필요한 로그라는 판단에 따라 삭제하고자 함

## 참고자료(선택)
https://github.com/boostcampwm-2024/web34-LearnDocker/wiki/%EA%B0%9C%EB%B0%9C%EA%B8%B0%EB%A1%9D_J114%EB%B0%95%EC%84%B8%ED%99%98_3%EC%A3%BC7%EC%9D%BC%EC%B0%A8_logrotate-on-production-server