### PR TITLE
학습 시작 버튼 누를 시 Timer생성 및 정적 페이지 라우팅 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,10 @@ import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 import LandingPage from './components/LandingPage';
 import ImagePullPage from './components/ImagePullPage';
+import WhatIsDockerPage from './components/DockerPage';
+import WhatIsDockerImagePage from './components/DockerImagePage';
+import DockerContainerLifeCyclePage from './components/DockerContainerLifeCyclePage';
+import DockerContainerPage from './components/DockerContainerPage';
 import ErrorPage from './components/ErrorPage';
 import { Routes, Route } from 'react-router-dom';
 
@@ -13,7 +17,14 @@ const App = () => {
                 <Sidebar />
                 <Routes>
                     <Route path='/' element={<LandingPage />} />
+                    <Route path='/what-is-docker' element={<WhatIsDockerPage />} />
+                    <Route path='/what-is-docker-image' element={<WhatIsDockerImagePage />} />
                     <Route path='/image/quiz/1' element={<ImagePullPage />} />
+                    <Route path='/what-is-docker-container' element={<DockerContainerPage />} />
+                    <Route
+                        path='/what-is-container-lifecycle'
+                        element={<DockerContainerLifeCyclePage />}
+                    />
                     <Route path='/error/:id' element={<ErrorPage />} />
                 </Routes>
             </div>

--- a/frontend/src/api/timer.ts
+++ b/frontend/src/api/timer.ts
@@ -4,11 +4,9 @@ import { ExpirationTime } from '../types/timer';
 const PROXY_HOST = import.meta.env.VITE_PROXY_HOST;
 const PROXY_PORT = import.meta.env.VITE_PROXY_PORT;
 
-export const requestExpriationTime = async (): Promise<ExpirationTime> => {
+export const requestExpriationTime = async (): Promise<ExpirationTime | object> => {
     // Todo: 테스트용 return 백엔드 구현 완료되면 아래 코드 사용할 예정
-    return {
-        maxAge: '2024-11-18T21:50',
-    };
+    return {};
     try {
         const response = await axios.get<ExpirationTime>(
             `http://${PROXY_HOST}:${PROXY_PORT}/api/maxAge`

--- a/frontend/src/api/timer.ts
+++ b/frontend/src/api/timer.ts
@@ -5,6 +5,10 @@ const PROXY_HOST = import.meta.env.VITE_PROXY_HOST;
 const PROXY_PORT = import.meta.env.VITE_PROXY_PORT;
 
 export const requestExpriationTime = async (): Promise<ExpirationTime> => {
+    // Todo: 테스트용 return 백엔드 구현 완료되면 아래 코드 사용할 예정
+    return {
+        maxAge: '2024-11-18T21:50',
+    };
     try {
         const response = await axios.get<ExpirationTime>(
             `http://${PROXY_HOST}:${PROXY_PORT}/api/maxAge`

--- a/frontend/src/api/timer.ts
+++ b/frontend/src/api/timer.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+import { ExpirationTime } from '../types/timer';
+
+const PROXY_HOST = import.meta.env.VITE_PROXY_HOST;
+const PROXY_PORT = import.meta.env.VITE_PROXY_PORT;
+
+export const requestExpriationTime = async (): Promise<ExpirationTime> => {
+    try {
+        const response = await axios.get<ExpirationTime>(
+            `http://${PROXY_HOST}:${PROXY_PORT}/api/maxAge`
+        );
+        return response.data;
+    } catch (error) {
+        console.error(error);
+        return {
+            maxAge: new Date(0).toString(),
+        };
+    }
+};

--- a/frontend/src/components/DockerContainerLifeCyclePage.tsx
+++ b/frontend/src/components/DockerContainerLifeCyclePage.tsx
@@ -1,0 +1,8 @@
+const DockerContainerLifeCyclePage = () => {
+    return (
+        <>
+            <h1>Container생명주기에 대해서 알아볼까요?</h1>
+        </>
+    );
+};
+export default DockerContainerLifeCyclePage;

--- a/frontend/src/components/DockerContainerPage.tsx
+++ b/frontend/src/components/DockerContainerPage.tsx
@@ -1,0 +1,9 @@
+const DockerContainerPage = () => {
+    return (
+        <>
+            <h1>Docker container란 무엇일까요?</h1>
+        </>
+    );
+};
+
+export default DockerContainerPage;

--- a/frontend/src/components/DockerImagePage.tsx
+++ b/frontend/src/components/DockerImagePage.tsx
@@ -1,0 +1,9 @@
+const WhatIsDockerImagePage = () => {
+    return (
+        <>
+            <h1>Docker Image란 무엇일까요?</h1>
+        </>
+    );
+};
+
+export default WhatIsDockerImagePage;

--- a/frontend/src/components/DockerPage.tsx
+++ b/frontend/src/components/DockerPage.tsx
@@ -1,0 +1,9 @@
+const WhatIsDockerPage = () => {
+    return (
+        <>
+            <h1>Docker란 무엇일까요??</h1>
+        </>
+    );
+};
+
+export default WhatIsDockerPage;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { SidebarSectionProps } from '../types/sidebar';
 import { Timer } from './Timer';
 import { requestExpriationTime } from '../api/timer';
+import { ExpirationTime } from '../types/timer';
 
 const links = [
     { title: 'Home', path: '/' },
@@ -67,7 +68,8 @@ const Sidebar = () => {
         const fetchTime = async () => {
             const data = await requestExpriationTime();
             if (Object.keys(data).includes('maxAge')) {
-                const maxAge = new Date(data.maxAge).getTime();
+                const expirationData = data as ExpirationTime;
+                const maxAge = new Date(expirationData.maxAge).getTime();
                 setMaxAge(maxAge);
             }
         };
@@ -87,8 +89,7 @@ const Sidebar = () => {
                 <SidebarSection title='Docker Image 학습' links={dockerImageLinks} />
                 <SidebarSection title='Docker Container 학습' links={dockerContainerLinks} />
             </div>
-            {maxAge && <Timer expirationTime={maxAge} />}
-            {!maxAge && <StartButton />}
+            {maxAge ? <Timer expirationTime={maxAge} /> : <StartButton setMaxAge={setMaxAge} />}
         </nav>
     );
 };

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import dropDownImage from '../assets/dropDown.svg';
 import StartButton from './StartButton';
 import { Link } from 'react-router-dom';
 import { SidebarSectionProps } from '../types/sidebar';
+import { Timer } from './Timer';
 
 const links = [
     { title: 'Home', path: '/' },
@@ -75,6 +76,7 @@ const Sidebar = () => {
                 <SidebarSection title='Docker Container 학습' links={dockerContainerLinks} />
             </div>
             <StartButton />
+            <Timer />
         </nav>
     );
 };

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import dropDownImage from '../assets/dropDown.svg';
 import StartButton from './StartButton';
 import { Link } from 'react-router-dom';
 import { SidebarSectionProps } from '../types/sidebar';
 import { Timer } from './Timer';
+import { requestExpriationTime } from '../api/timer';
 
 const links = [
     { title: 'Home', path: '/' },
@@ -61,6 +62,17 @@ const SidebarSection = ({ title, links }: SidebarSectionProps) => {
 };
 
 const Sidebar = () => {
+    const [maxAge, setMaxAge] = useState<number>(0);
+    useEffect(() => {
+        const fetchTime = async () => {
+            const data = await requestExpriationTime();
+            if (Object.keys(data).includes('maxAge')) {
+                const maxAge = new Date(data.maxAge).getTime();
+                setMaxAge(maxAge);
+            }
+        };
+        fetchTime();
+    }, []);
     return (
         <nav className='flex flex-col text-Off-Black h-[calc(100vh-4rem)] w-[17rem] bg-gray-100'>
             <div className='flex-grow'>
@@ -75,8 +87,8 @@ const Sidebar = () => {
                 <SidebarSection title='Docker Image 학습' links={dockerImageLinks} />
                 <SidebarSection title='Docker Container 학습' links={dockerContainerLinks} />
             </div>
-            <StartButton />
-            <Timer />
+            {maxAge && <Timer expirationTime={maxAge} />}
+            {!maxAge && <StartButton />}
         </nav>
     );
 };

--- a/frontend/src/components/StartButton.tsx
+++ b/frontend/src/components/StartButton.tsx
@@ -2,16 +2,24 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createHostContainer } from '../api/quiz';
 import { LoaderCircle } from 'lucide-react';
+import { MAX_TIME } from '../types/timer';
 
-const StartButton = () => {
+type StartButtonProps = {
+    setMaxAge: React.Dispatch<React.SetStateAction<number>>;
+};
+
+const StartButton = (props: StartButtonProps) => {
     const navigate = useNavigate();
     const [loading, setLoading] = useState(false);
+    const { setMaxAge } = props;
 
     const handleButtonClick = async () => {
         setLoading(true);
-        const success =  await createHostContainer(navigate);
+        const success = await createHostContainer(navigate);
+        console.log(success);
         if (success) {
             setLoading(false);
+            setMaxAge(new Date().getTime() + MAX_TIME);
         }
     };
 

--- a/frontend/src/components/StartButton.tsx
+++ b/frontend/src/components/StartButton.tsx
@@ -16,7 +16,7 @@ const StartButton = (props: StartButtonProps) => {
     const handleButtonClick = async () => {
         setLoading(true);
         const success = await createHostContainer(navigate);
-        console.log(success);
+
         if (success) {
             setLoading(false);
             setMaxAge(new Date().getTime() + MAX_TIME);

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -15,9 +15,13 @@ const parseTime = (time: number) => {
     return `${String(hour).padStart(2, '0')} : ${String(minute).padStart(2, '0')} : ${String(second).padStart(2, '0')}`;
 };
 
-export const Timer = () => {
-    const [leftTime, setLeftTime] = useState(MAX_TIME);
+type TimerProps = {
+    expirationTime: number;
+};
 
+export const Timer = (props: TimerProps) => {
+    const expriationTime = props.expirationTime || new Date().getTime() + MAX_TIME;
+    const [leftTime, setLeftTime] = useState(expriationTime - new Date().getTime());
     useEffect(() => {
         const timer = setInterval(() => setLeftTime(leftTime - SECOND), SECOND);
         if (leftTime < 0) clearInterval(timer);

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -31,5 +31,11 @@ export const Timer = (props: TimerProps) => {
         };
     }, [leftTime]);
 
-    return <>{parseTime(leftTime)}</>;
+    return (
+        <>
+            <span className='flex justify-center align-middle font-bold text-Moby-Blue text-3xl content-center mb-5'>
+                {parseTime(leftTime)}
+            </span>
+        </>
+    );
 };

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useState } from 'react';
-
-const SECOND = 1000;
-const MINUTE = 60 * SECOND;
-const HOUR = 60 * MINUTE;
-const MAX_TIME = 4 * HOUR;
+import { HOUR, MINUTE, SECOND, MAX_TIME } from '../types/timer';
 
 const parseTime = (time: number) => {
     const hour = Math.floor(time / HOUR);

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const MAX_TIME = 4 * HOUR;
+
+const parseTime = (time: number) => {
+    const hour = Math.floor(time / HOUR);
+    time %= HOUR;
+    const minute = Math.floor(time / MINUTE);
+    time %= MINUTE;
+    const second = Math.floor(time / 1000);
+
+    return `${String(hour).padStart(2, '0')} : ${String(minute).padStart(2, '0')} : ${String(second).padStart(2, '0')}`;
+};
+
+export const Timer = () => {
+    const [leftTime, setLeftTime] = useState(MAX_TIME);
+
+    useEffect(() => {
+        const timer = setInterval(() => setLeftTime(leftTime - SECOND), SECOND);
+        if (leftTime < 0) clearInterval(timer);
+
+        return () => {
+            clearInterval(timer);
+        };
+    }, [leftTime]);
+
+    return <>{parseTime(leftTime)}</>;
+};

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -21,6 +21,7 @@ const QuizButtons = () => {
         // TODO: submitResult의 상태에 따라 모달창을 띄워줘야 한다.
         // 아래 console.log는 테스트 용도, 나중에 삭제해야 함
         // 여기서 해줄 작업은 없고, 아래 jsx를 return해줄 때 모달창 띄우는 코드를 추가해야 할 듯 합니다.
+        console.log(submitResult);
     };
 
     // TODO: 이전. 다음버튼에 이벤트 추가가 필요합니다.

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -21,7 +21,6 @@ const QuizButtons = () => {
         // TODO: submitResult의 상태에 따라 모달창을 띄워줘야 한다.
         // 아래 console.log는 테스트 용도, 나중에 삭제해야 함
         // 여기서 해줄 작업은 없고, 아래 jsx를 return해줄 때 모달창 띄우는 코드를 추가해야 할 듯 합니다.
-        console.log(submitResult);
     };
 
     // TODO: 이전. 다음버튼에 이벤트 추가가 필요합니다.

--- a/frontend/src/types/timer.ts
+++ b/frontend/src/types/timer.ts
@@ -1,3 +1,8 @@
 export type ExpirationTime = {
     maxAge: string;
 };
+
+export const SECOND = 1000;
+export const MINUTE = 60 * SECOND;
+export const HOUR = 60 * MINUTE;
+export const MAX_TIME = 4 * HOUR;

--- a/frontend/src/types/timer.ts
+++ b/frontend/src/types/timer.ts
@@ -1,0 +1,3 @@
+export type ExpirationTime = {
+    maxAge: string;
+};


### PR DESCRIPTION
## 작업 개요

- #105 
- #10 
- #11 
- #12 

## 작업 상세 내용

- [x] Timer구현하기
     - [x] Timer컴포넌트 구현
     - [x] StartButton누를 시 Timer컴포넌트 생성
     - [x] 새로고침 시 시간 유지
- [x] 정적 페이지 라우팅


### 버튼 누를 시 타이머 실행

https://github.com/user-attachments/assets/d9f6efa5-6d8c-4ffa-9bd1-be0fc28a3d83


### 새로고침 시 시간 유지

https://github.com/user-attachments/assets/7e57d584-426a-483b-935b-1f4092dc8a35

### 정적 페이지 라우팅

`SideBar`컴포넌트 내 `Link`컴포넌트에 해당하는 경로대로 `React Router`를 활용하여 라우팅 하도록 구현하였음
```
const App = () => {
    return (
        <>
            <Header />
            <div className='flex font-pretendard'>
                <Sidebar />
                <Routes>
                    <Route path='/' element={<LandingPage />} />
                    <Route path='/what-is-docker' element={<WhatIsDockerPage />} />
                    <Route path='/what-is-docker-image' element={<WhatIsDockerImagePage />} />
                    <Route path='/image/quiz/1' element={<ImagePullPage />} />
                    <Route path='/what-is-docker-container' element={<DockerContainerPage />} />
                    <Route
                        path='/what-is-container-lifecycle'
                        element={<DockerContainerLifeCyclePage />}
                    />
                    <Route path='/error/:id' element={<ErrorPage />} />
                </Routes>
            </div>
        </>
    );
};
```

## 참고자료(선택)

## 문제점 혹은 고민(선택)

### 빠르게 새로고침 시 문제

세션이 존재하고, 타이머가 돌고있는 상황에서 새로고침 시 `StartButton`컴포넌트가 아주 잠깐 생겼다가 없어짐

해당 문제는 `maxAge`데이터를 백엔드로부터 가져오는 딜레이 시간동안만 `StartButton`이 보이는 것으로 파악됨

https://github.com/user-attachments/assets/745fe3cc-2926-46a2-90f5-0d655d5c354b

### 정적페이지 구성

[페이지 설계](https://www.figma.com/design/ClXaOWYkYfv4tgEanGfBq6/%EB%A0%88%EC%9D%B4%EC%95%84%EC%9B%83-%EC%84%A4%EA%B3%84?node-id=5-2&node-type=canvas&t=uc4J1GtjJM56NYOh-0)

피그마에 정적 페이지들의 구성을 조금 짜봤습니다.. 생각보다 너무 많아서 나눠서 해야할 지 태스크를 할당받은 제가 해야할 지 이야기 해보면 좋을 것 같습니다.

