### PR TITLE
이미지 가져오기 퀴즈 채점 관련 백엔드 API 구현

### DIFF
--- a/backend/src/common/auth/auth.guard.ts
+++ b/backend/src/common/auth/auth.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+    private readonly Logger = new Logger(AuthGuard.name);
+
+    constructor(private readonly authService: AuthService) {}
+
+    canActivate(context: ExecutionContext) {
+        const request = context.switchToHttp().getRequest();
+
+        const sessionId = request.cookies['sid'];
+        this.Logger.debug(`Session ID: ${sessionId}`);
+
+        const session = this.authService.validateSession(sessionId);
+
+        request.session = session;
+
+        return true;
+    }
+}

--- a/backend/src/common/auth/auth.module.ts
+++ b/backend/src/common/auth/auth.module.ts
@@ -1,11 +1,12 @@
 import { Global, Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CacheModule } from '../cache/cache.module';
+import { AuthGuard } from './auth.guard';
 
 @Global()
 @Module({
-  imports: [CacheModule],
-  providers: [AuthService],
-  exports: [AuthService],
+    imports: [CacheModule],
+    providers: [AuthService, AuthGuard],
+    exports: [AuthGuard, AuthService],
 })
 export class AuthModule {}

--- a/backend/src/common/cache/cache.service.ts
+++ b/backend/src/common/cache/cache.service.ts
@@ -1,10 +1,5 @@
 import { Injectable } from '@nestjs/common';
-
-export interface ContainerSession {
-    containerId: string;
-    startTime: Date;
-    renew: boolean;
-}
+import { ContainerSession } from '../types/session';
 
 @Injectable()
 export class CacheService {

--- a/backend/src/common/exception/filters.ts
+++ b/backend/src/common/exception/filters.ts
@@ -34,7 +34,11 @@ export class LastExceptionFilter implements ExceptionFilter {
         };
 
         if (this.constructor.name === 'LastExceptionFilter') {
-            this.logger.error(exception);
+            if (exception instanceof Error) {
+                this.logger.error(exception.message, exception);
+            } else {
+                this.logger.error(exception);
+            }
         }
 
         httpAdapter.reply(ctx.getResponse(), responseBody, httpStatus);
@@ -44,6 +48,7 @@ export class LastExceptionFilter implements ExceptionFilter {
 @Catch(HttpException)
 export class HttpExceptionsFilter extends LastExceptionFilter {
     catch(exception: HttpException, host: ArgumentsHost) {
+        this.logger.debug(exception);
         super.catch(exception, host);
     }
 }
@@ -51,6 +56,7 @@ export class HttpExceptionsFilter extends LastExceptionFilter {
 @Catch(BusinessException)
 export class BusinessExceptionsFilter extends LastExceptionFilter {
     catch(exception: unknown, host: ArgumentsHost) {
+        this.logger.debug(exception);
         if (exception instanceof SessionAlreadyAssignedException) {
             super.catch(new ForbiddenException(exception), host);
             return;

--- a/backend/src/common/types/request.ts
+++ b/backend/src/common/types/request.ts
@@ -1,0 +1,6 @@
+import { ContainerSession } from "./session";
+import { Request } from "express";
+
+export interface RequestWithSession extends Request {
+    session: ContainerSession;
+}

--- a/backend/src/common/types/session.ts
+++ b/backend/src/common/types/session.ts
@@ -1,0 +1,5 @@
+export interface ContainerSession {
+    containerId: string;
+    startTime: Date;
+    renew: boolean;
+}

--- a/backend/src/quiz/quiz.controller.ts
+++ b/backend/src/quiz/quiz.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Req, UseGuards } from '@nestjs/common';
 import { QuizService } from './quiz.service';
 import { AuthGuard } from '../common/auth/auth.guard';
+import { RequestWithSession } from '../common/types/request';
 
 @Controller('quiz')
 export class QuizController {
@@ -10,5 +11,12 @@ export class QuizController {
     @UseGuards(AuthGuard)
     getQuizById(@Param('id', ParseIntPipe) id: number) {
         return this.quizService.getQuizById(id)
+    }
+
+    @Get('/:id/submit')
+    @UseGuards(AuthGuard)
+    submitQuiz(@Param('id', ParseIntPipe) quizId: number, @Req() req: RequestWithSession) {
+        const {containerId} = req.session
+        return this.quizService.submitQuiz(quizId, containerId)
     }
 }

--- a/backend/src/quiz/quiz.controller.ts
+++ b/backend/src/quiz/quiz.controller.ts
@@ -1,11 +1,13 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
 import { QuizService } from './quiz.service';
+import { AuthGuard } from '../common/auth/auth.guard';
 
 @Controller('quiz')
 export class QuizController {
     constructor(private quizService: QuizService) {}
 
     @Get('/:id')
+    @UseGuards(AuthGuard)
     getQuizById(@Param('id', ParseIntPipe) id: number) {
         return this.quizService.getQuizById(id)
     }

--- a/backend/src/quiz/quiz.module.ts
+++ b/backend/src/quiz/quiz.module.ts
@@ -3,10 +3,11 @@ import { QuizController } from './quiz.controller';
 import { QuizService } from './quiz.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Quiz } from './quiz.entity';
+import { SandboxModule } from '../sandbox/sandbox.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Quiz])],
-  controllers: [QuizController],
-  providers: [QuizService]
+    imports: [TypeOrmModule.forFeature([Quiz]), SandboxModule],
+    controllers: [QuizController],
+    providers: [QuizService],
 })
 export class QuizModule {}

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -1,14 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, MethodNotAllowedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Quiz } from './quiz.entity';
 import { EntityNotExistException } from '../common/exception/errors';
+import { SandboxService } from 'src/sandbox/sandbox.service';
 
 @Injectable()
 export class QuizService {
     constructor(
         @InjectRepository(Quiz)
-        private quizRepository: Repository<Quiz>
+        private readonly quizRepository: Repository<Quiz>,
+        private readonly sandboxService: SandboxService
     ) {}
 
     async getQuizById(id: number) {
@@ -17,5 +19,20 @@ export class QuizService {
             throw new EntityNotExistException('Quiz');
         }
         return quiz;
+    }
+
+    async submitQuiz(quizId: number, containerId: string) {
+        switch (quizId) {
+            case 1: {
+                const command = 'docker inspect hello-world';
+                const output = await this.sandboxService.processUserCommand(command, containerId);
+                if (typeof output === 'object') {
+                    return { quizResult: 'SUCESS' };
+                }
+                return { quizResult: 'FAIL' };
+            }
+            default:
+                throw new MethodNotAllowedException(`${quizId}번 퀴즈는 아직 채점할 수 없습니다.`);
+        }
     }
 }

--- a/backend/src/sandbox/pipes/command.pipe.ts
+++ b/backend/src/sandbox/pipes/command.pipe.ts
@@ -4,7 +4,8 @@ const VALID_REGEX = /^docker\s(?:(?!.*\b(?:sh|bash|exec)\b|.*[;&|<>$`]))/;
 
 @Injectable()
 export class CommandValidationPipe implements PipeTransform {
-    transform(value: any) {
+    transform(value: string) {
+        value = value.trim();
         const validation = value.match(VALID_REGEX);
         if (!validation) throw new BadRequestException('해당 명령어는 사용이 불가능합니다!');
         return value;

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -16,11 +16,12 @@ export class SandboxController {
     }
 
     @Post('command')
-    processUserCommand(@Body('command', CommandValidationPipe) command: string) {
-        return this.sandboxService.processUserCommand(
-            command,
-            '13d33cb7b795a4d635f0b3bfd91d5809501876c874151a0fd4a32ad0d43a6da3'
-        );
+    processUserCommand(
+        @Req() req: Request,
+        @Body('command', CommandValidationPipe) command: string
+    ) {
+        const sessionId = req.cookies['sid'];
+        return this.sandboxService.processUserCommand(command, sessionId);
     }
 
     @Post('start')

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -5,12 +5,8 @@ import { Request, Response } from 'express';
 import { SESSION_DURATION } from '../common/constant';
 import { HideInProduction } from '../common/decorator/hide-in-production.decorator';
 import { AuthGuard } from '../common/auth/auth.guard';
-import { ContainerSession } from '../common/cache/cache.service';
 import { AuthService } from '../common/auth/auth.service';
-
-interface RequestWithSession extends Request {
-    session: ContainerSession;
-}
+import { RequestWithSession } from '../common/types/request';
 
 @Controller('sandbox')
 export class SandboxController {
@@ -37,7 +33,7 @@ export class SandboxController {
     async assignContainer(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
         const sessionId = req.cookies['sid'];
         this.authService.throwIfSessionIsValid(sessionId);
-        
+
         const newSessionId = await this.sandboxService.assignContainer();
         res.cookie('sid', newSessionId, { httpOnly: true, maxAge: SESSION_DURATION });
     }

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -1,33 +1,44 @@
-import { Controller, Get, Post, Body, Delete, Req, Res } from '@nestjs/common';
+import { Controller, Get, Post, Body, Delete, Req, Res, UseGuards } from '@nestjs/common';
 import { SandboxService } from './sandbox.service';
 import { CommandValidationPipe } from './pipes/command.pipe';
 import { Request, Response } from 'express';
 import { SESSION_DURATION } from '../common/constant';
 import { HideInProduction } from '../common/decorator/hide-in-production.decorator';
+import { AuthGuard } from '../common/auth/auth.guard';
+import { ContainerSession } from '../common/cache/cache.service';
+import { AuthService } from '../common/auth/auth.service';
+
+interface RequestWithSession extends Request {
+    session: ContainerSession;
+}
 
 @Controller('sandbox')
 export class SandboxController {
-    constructor(private sandboxService: SandboxService) {}
+    constructor(private readonly sandboxService: SandboxService, private readonly authService: AuthService) {}
 
     @Get('elements')
-    getUserContainersImages(@Req() req: Request) {
-        const sessionId = req.cookies['sid'];
-        return this.sandboxService.getUserContainerImages(sessionId);
+    @UseGuards(AuthGuard)
+    getUserContainersImages(@Req() req: RequestWithSession) {
+        const { containerId } = req.session;
+        return this.sandboxService.getUserContainerImages(containerId);
     }
 
     @Post('command')
+    @UseGuards(AuthGuard)
     processUserCommand(
-        @Req() req: Request,
+        @Req() req: RequestWithSession,
         @Body('command', CommandValidationPipe) command: string
     ) {
-        const sessionId = req.cookies['sid'];
-        return this.sandboxService.processUserCommand(command, sessionId);
+        const { containerId } = req.session;
+        return this.sandboxService.processUserCommand(command, containerId);
     }
 
     @Post('start')
     async assignContainer(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
         const sessionId = req.cookies['sid'];
-        const newSessionId = await this.sandboxService.assignContainer(sessionId);
+        this.authService.throwIfSessionIsValid(sessionId);
+        
+        const newSessionId = await this.sandboxService.assignContainer();
         res.cookie('sid', newSessionId, { httpOnly: true, maxAge: SESSION_DURATION });
     }
 

--- a/backend/src/sandbox/sandbox.module.ts
+++ b/backend/src/sandbox/sandbox.module.ts
@@ -13,5 +13,6 @@ import { CacheModule } from '../common/cache/cache.module';
     ],
     providers: [SandboxService],
     controllers: [SandboxController],
+    exports: [SandboxService],
 })
 export class SandboxModule {}

--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -54,7 +54,12 @@ export class SandboxService {
         return filterImageInfo(imageList);
     }
 
-    async processUserCommand(command: string, containerId: string) {
+    async processUserCommand(command: string, sessionId: string) {
+        const isValidSession = this.authService.validateSession(sessionId);
+        if (!isValidSession) {
+            throw new InvalidSessionException();
+        }
+        const { containerId } = this.cacheService.get(sessionId) as ContainerSession;
         return requestDockerCommand(this.httpService, containerId, command.split(' '));
     }
 

--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -1,12 +1,10 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable, Inject, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { parseStringToJson, filterContainerInfo, filterImageInfo } from './utils';
 import { requestDockerCommand } from './exec.api';
 import { ContainerData, ImageData } from './types/elements';
-import { CacheService, ContainerSession } from '../common/cache/cache.service';
+import { CacheService } from '../common/cache/cache.service';
 import { randomUUID } from 'crypto';
-import { AuthService } from '../common/auth/auth.service';
-import { InvalidSessionException, SessionAlreadyAssignedException } from '../common/exception/errors';
 
 @Injectable()
 export class SandboxService {
@@ -15,17 +13,9 @@ export class SandboxService {
     constructor(
         private readonly httpService: HttpService,
         private readonly cacheService: CacheService,
-        @Inject(AuthService) private readonly authService: AuthService
     ) {}
 
-    async getUserContainerImages(sessionId: string) {
-        const isValidSession = this.authService.validateSession(sessionId);
-        if (!isValidSession) {
-            throw new InvalidSessionException();
-        }
-
-        const { containerId } = this.cacheService.get(sessionId) as ContainerSession;
-
+    async getUserContainerImages(containerId: string) {
         const containers = await requestDockerCommand(this.httpService, containerId, [
             'docker',
             'ps',
@@ -54,12 +44,7 @@ export class SandboxService {
         return filterImageInfo(imageList);
     }
 
-    async processUserCommand(command: string, sessionId: string) {
-        const isValidSession = this.authService.validateSession(sessionId);
-        if (!isValidSession) {
-            throw new InvalidSessionException();
-        }
-        const { containerId } = this.cacheService.get(sessionId) as ContainerSession;
+    async processUserCommand(command: string, containerId: string) {
         return requestDockerCommand(this.httpService, containerId, command.split(' '));
     }
 
@@ -83,12 +68,7 @@ export class SandboxService {
         );
     }
 
-    async assignContainer(sessionId?: string) {
-        const isValidSession = this.authService.validateSession(sessionId);
-        if (isValidSession) {
-            throw new SessionAlreadyAssignedException();
-        }
-
+    async assignContainer() {
         const containerId = await this.createContainer();
         try {
             await this.startContainer(containerId);


### PR DESCRIPTION
## 작업 개요

Resolves #197, resolves #199, resolves #203 



## 작업 상세 내용

- `/api/sandbox/command` 에 대응되는 POST controller에서 하드코딩된 컨테이너 ID 제거
- 세션을 확인하는 인증 가드 적용
  - 세션이 유효한지 확인 후, request 객체에 session (컨테이너 ID, startTime 등) 객체를 삽입
- 이미지 가져오기 퀴즈에 대한 채점 API 구현 (`/api/quiz/1/submit`)
  - docker inspect hello-world를 사용, 출력값이 빈 배열이면 hello-world가 없다고 판단.

## 참고 사항

- 샌드박스 서버가 프라이빗 서브넷 내부에 존재하므로, `docker pull tt6gplno.kr.private-ncr.ntruss.com/hello-world`로 이미지를 다운로드받아야 함

## 참고자료(선택)

## 문제점 혹은 고민(선택)