### PR TITLE
사용자 image, container 시각화 정보 요청 API를 포트 매핑 방식으로 변경

### DIFF
--- a/backend/src/common/types/session.ts
+++ b/backend/src/common/types/session.ts
@@ -1,5 +1,6 @@
 export interface ContainerSession {
     containerId: string;
+    containerPort: string;
     startTime: Date;
     renew: boolean;
 }

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -42,12 +42,12 @@ export class SandboxController {
         res.cookie('sid', newSessionId, { httpOnly: true, maxAge: SESSION_DURATION });
     }
 
-    @Get('maxAge')
+    @Get('endDate')
     @UseGuards(AuthGuard)
     getMaxAge(@Req() req: RequestWithSession) {
         const { startTime } = req.session;
         const endDate = new Date(startTime.getTime() + SESSION_DURATION);
-        return { maxAge: endDate };
+        return { endDate };
     }
 
     // 개발용 API입니다. 배포 시 노출되면 안됩니다.

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -10,13 +10,17 @@ import { RequestWithSession } from '../common/types/request';
 
 @Controller('sandbox')
 export class SandboxController {
-    constructor(private readonly sandboxService: SandboxService, private readonly authService: AuthService) {}
+    constructor(
+        private readonly sandboxService: SandboxService,
+        private readonly authService: AuthService
+    ) {}
 
     @Get('elements')
     @UseGuards(AuthGuard)
     getUserContainersImages(@Req() req: RequestWithSession) {
-        const { containerId } = req.session;
-        return this.sandboxService.getUserContainerImages(containerId);
+        const { containerPort } = req.session;
+        // return this.sandboxService.getUserContainerImages(containerId);
+        return this.sandboxService.getUserContainerImagesV2(containerPort);
     }
 
     @Post('command')

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -42,6 +42,14 @@ export class SandboxController {
         res.cookie('sid', newSessionId, { httpOnly: true, maxAge: SESSION_DURATION });
     }
 
+    @Get('maxAge')
+    @UseGuards(AuthGuard)
+    getMaxAge(@Req() req: RequestWithSession) {
+        const { startTime } = req.session;
+        const endDate = new Date(startTime.getTime() + SESSION_DURATION);
+        return { maxAge: endDate };
+    }
+
     // 개발용 API입니다. 배포 시 노출되면 안됩니다.
     @Delete('clear')
     @HideInProduction()


### PR DESCRIPTION
## 작업 개요

- #26 
- #34 
- #42 
- #50 

## 작업 상세 내용

- [x] 컨테이너 포트 번호 매핑
- [x] 사용자 컨테이너, 이미지 목록 요청 로직을 포트를 사용하여 처리
  - [x] exec 대신 http://${SANDBOX_HOST}:${containerPort}/images/json 과 같은 형태로 사용
- [x] 타이머를 위한 maxAge API 구현
   - [x] 정상적인 경우 200 상태코드
   - [x] 세션이 존재하지 않으면 403 에러

## 문제점 혹은 고민

### 컨테이너 포트 매핑 관련
- 현재 사용자별 호스트 컨테이너 포트를 매핑하는 형태로 구현을 진행했는데, 초기에 네트워크가 세팅이 되기까지 시간이 필요한 것 같습니다.
- `시작하기` 버튼을 누르고 바로 퀴즈 페이지에 들어가서 도커 명령어를 치면 ECONNREFUSED 에러가 발생해서 사용자 입장에서는 500 에러 페이지로 가게 됩니다.
- 이 부분에 대한 에러 처리 로직을 추가해서 사용자에게 조금 있다가 다시 시도하게 할지, 아니면 포트 번호 매핑을 포기하고 다시 exec로 돌아가는 것이 좋을 지 고민입니다.

![ECONNREFUSED](https://github.com/user-attachments/assets/5ad506e8-7882-4300-9497-ce660d319755)

### timer API 관련

- 기존에 생각한 경로가 `/api/maxAge`였는데 `/api/sandbox/maxAge`로 변경했습니다.
- 세션 정보가 없는 경우 200 상태코드에 {} 빈 객체를 반환한다는 설정에서 403 에러를 반환하는 형태로 변경 되었습니다.
- 현재와 같은 구조도 괜찮을지 고민입니다.

