### PR TITLE
Axios error formatting, Error rotating property fix

### DIFF
--- a/backend/src/common/exception/axios-formatter.ts
+++ b/backend/src/common/exception/axios-formatter.ts
@@ -1,0 +1,14 @@
+import { AxiosError } from 'axios';
+
+export function formatAxiosError(error: AxiosError) {
+    return {
+        message: error.message,
+        stack: error.stack,
+        cause: error.cause,
+        code: error.code,
+        url: error.config?.url,
+        method: error.config?.method,
+        status: error.response?.status,
+        responseData: error.response?.data,
+    };
+}

--- a/backend/src/common/exception/filters.ts
+++ b/backend/src/common/exception/filters.ts
@@ -16,6 +16,8 @@ import {
     PreviousProblemUnsolvedExeption,
     SessionAlreadyAssignedException,
 } from './errors';
+import { isAxiosError } from 'axios';
+import { formatAxiosError } from './axios-formatter';
 
 @Catch()
 export class LastExceptionFilter implements ExceptionFilter {
@@ -40,8 +42,8 @@ export class LastExceptionFilter implements ExceptionFilter {
         };
 
         if (this.constructor.name === 'LastExceptionFilter') {
-            if (exception instanceof Error) {
-                this.logger.error(exception.message, exception);
+            if (isAxiosError(exception)) {
+                this.logger.error(formatAxiosError(exception));
             } else {
                 this.logger.error(exception);
             }

--- a/backend/src/common/logger/config.ts
+++ b/backend/src/common/logger/config.ts
@@ -4,7 +4,7 @@ import DailyRotateFile from 'winston-daily-rotate-file';
 
 const productionFormat = winston.format.combine(
     winston.format.timestamp({
-        format: 'YYYY-MM-DD HH:mm:ss',
+        format: 'YY-MM-DD HH:mm:ss',
     }),
     winston.format.ms(),
     nestWinstonModuleUtilities.format.nestLike('SandBoxProxy', {
@@ -14,7 +14,7 @@ const productionFormat = winston.format.combine(
 );
 const developmentFormat = winston.format.combine(
     winston.format.timestamp({
-        format: 'YYYY-MM-DD HH:mm:ss',
+        format: 'YY-MM-DD HH:mm:ss',
     }),
     winston.format.ms(),
     nestWinstonModuleUtilities.format.nestLike('SandBoxProxy', {
@@ -29,22 +29,23 @@ const productionTransports = [
         level: 'info',
         dirname: 'logs/log',
         filename: '%DATE%.log',
-        datePattern: 'YYYY-MM-DD',
+        datePattern: 'YY-MM-DD_HH',
         zippedArchive: false,
         maxSize: '20m',
-        frequency: '1d',
+        frequency: '3h',
         maxFiles: '14d',
         format: productionFormat,
+        
     }),
     // Error 레벨 로그
     new DailyRotateFile({
         level: 'error',
         dirname: 'logs/error',
         filename: '%DATE%.log',
-        datePattern: 'YYYY-MM-DD',
+        datePattern: 'YY-MM-DD_HH',
         zippedArchive: false,
         maxSize: '20m',
-        frequency: '1d',
+        frequency: '3h',
         maxFiles: '14d',
         format: productionFormat,
     }),

--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -5,6 +5,8 @@ import { requestDockerCommand } from './exec.api';
 import { Container, ContainerData, Image, ImageData } from './types/elements';
 import { CacheService } from '../common/cache/cache.service';
 import { randomUUID } from 'crypto';
+import { formatAxiosError } from '../common/exception/axios-formatter';
+import { isAxiosError } from 'axios';
 
 @Injectable()
 export class SandboxService {
@@ -55,7 +57,9 @@ export class SandboxService {
             const containers = this.parseContainersV2(containerResponse);
             return { images, containers };
         } catch (error) {
-            this.logger.error(error);
+            if (isAxiosError(error)) {
+                this.logger.error(formatAxiosError(error));
+            }
             return { images: [], containers: [] };
         }
     }


### PR DESCRIPTION
## 작업 개요

closes #239 

- Axios Error formatting 함수 추가
- Winston Rotate 조건 변경

## 작업 상세 내용

### Axios Error formatting 함수 추가

`this.logger.error(AxiosError)`를 찍으면, 디버깅에 불필요한 속성이 나열되어 로그 보기에 상당히 불편했습니다.
필요하다고 판단되는 속성만 골라 log를 찍을 수 있게, formatAxiosError 함수를 추가합니다.

변경 후 로그)
![image](https://github.com/user-attachments/assets/507f3cba-b57e-4012-a99a-85eac28d96a2)


### Winston Rotate 조건 변경

기존 winston log Rotate 조건은 1일 이었습니다.
그러나 11월 22일자로 확인해본 결과, 하루 단위로 로그 파일이 나뉘지 않는 것을 확인했습니다.
[공식문서](https://github.com/winstonjs/winston-daily-rotate-file?tab=readme-ov-file#options)에 따르면, 파일이 생성되는 주기를 의미하는 frequency 옵션은 분, 시간 단위로만 넣을 수 있습니다.
따라서, rotate 조건을 3시간으로 변경, 파일 이름도 시간 단위를 추가해주었습니다.