### PR TITLE
컨테이너 실행하기 퀴즈 채점 기능 구현 및 QuizSubmitArea 컴포넌트 추가

### DIFF
--- a/backend/src/common/cache/cache.service.ts
+++ b/backend/src/common/cache/cache.service.ts
@@ -14,6 +14,13 @@ export class CacheService {
         this.store.set(key, value);
     }
 
+    updateLevel(key: string, level: number) {
+        const session = this.store.get(key);
+        if (session != null) {
+            session.level = level;
+        }
+    }
+
     delete(key: string) {
         this.store.delete(key);
     }

--- a/backend/src/common/types/session.ts
+++ b/backend/src/common/types/session.ts
@@ -1,4 +1,5 @@
 export interface UserSession {
+    sessionId: string;
     containerId: string;
     containerPort: string;
     startTime: Date;

--- a/backend/src/quiz/quiz.controller.ts
+++ b/backend/src/quiz/quiz.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query, Req, UseGuards } from '@nestjs/common';
 import { QuizService } from './quiz.service';
 import { AuthGuard } from '../common/auth/auth.guard';
 import { RequestWithSession } from '../common/types/request';
@@ -17,12 +17,17 @@ export class QuizController {
 
     @Get('/:id/submit')
     @UseGuards(AuthGuard)
-    submitQuiz(@Param('id', ParseIntPipe) quizId: number, @Req() req: RequestWithSession) {
+    submitQuiz(
+        @Param('id', ParseIntPipe) quizId: number,
+        @Req() req: RequestWithSession,
+        @Query('userAnswer') userAnswer?: string
+    ) {
         const sessionId = req.cookies['sid'];
         const { containerPort, level } = req.session;
 
         this.quizService.accessQuiz(level, quizId);
-        return this.quizService.submitQuiz(quizId, sessionId, containerPort, level);
+
+        return this.quizService.submitQuiz(quizId, sessionId, containerPort, level, userAnswer);
     }
 
     @Get('/:id/access')

--- a/backend/src/quiz/quiz.controller.ts
+++ b/backend/src/quiz/quiz.controller.ts
@@ -22,11 +22,8 @@ export class QuizController {
         @Req() req: RequestWithSession,
         @Query('userAnswer') userAnswer?: string
     ) {
-        const sessionId = req.cookies['sid'];
-        const { containerPort, level } = req.session;
-
+        const { sessionId, containerPort, level } = req.session;
         this.quizService.accessQuiz(level, quizId);
-
         return this.quizService.submitQuiz(quizId, sessionId, containerPort, level, userAnswer);
     }
 

--- a/backend/src/quiz/quiz.controller.ts
+++ b/backend/src/quiz/quiz.controller.ts
@@ -18,8 +18,11 @@ export class QuizController {
     @Get('/:id/submit')
     @UseGuards(AuthGuard)
     submitQuiz(@Param('id', ParseIntPipe) quizId: number, @Req() req: RequestWithSession) {
-        const { containerPort } = req.session;
-        return this.quizService.submitQuiz(quizId, containerPort);
+        const sessionId = req.cookies['sid'];
+        const { containerPort, level } = req.session;
+
+        this.quizService.accessQuiz(level, quizId);
+        return this.quizService.submitQuiz(quizId, sessionId, containerPort, level);
     }
 
     @Get('/:id/access')

--- a/backend/src/quiz/quiz.module.ts
+++ b/backend/src/quiz/quiz.module.ts
@@ -4,9 +4,10 @@ import { QuizService } from './quiz.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Quiz } from './quiz.entity';
 import { SandboxModule } from '../sandbox/sandbox.module';
+import { CacheModule } from '../common/cache/cache.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Quiz]), SandboxModule],
+    imports: [TypeOrmModule.forFeature([Quiz]), SandboxModule, CacheModule],
     controllers: [QuizController],
     providers: [QuizService],
 })

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -84,15 +84,22 @@ export class QuizService {
         }
     }
 
-    async submitQuiz(quizId: number, sessionId: string, containerPort: string, level: number) {
+    async submitQuiz(
+        quizId: number,
+        sessionId: string,
+        containerPort: string,
+        level: number,
+        userAnswer?: string
+    ) {
         switch (quizId) {
             case 1:
                 return this.submitQuiz1(sessionId, containerPort, level);
             case 4:
                 // 컨테이너 생성하기
                 return this.submitQuiz4(sessionId, containerPort, level);
-            // case 5:
-            // 컨테이너 실행하기
+            case 5:
+                //컨테이너 실행하기
+                return this.submitQuiz5(sessionId, userAnswer, level);
             default:
                 throw new MethodNotAllowedException(`${quizId}번 퀴즈는 아직 채점할 수 없습니다.`);
         }
@@ -120,6 +127,17 @@ export class QuizService {
         );
         if (result.length > 0) {
             this.updateLevel(sessionId, level, 5);
+            return { quizResult: 'SUCCESS' };
+        } else {
+            return { quizResult: 'FAIL' };
+        }
+    }
+
+    private async submitQuiz5(sessionId: string, userAnswer: string | undefined, level: number) {
+        const answer = 'docker start';
+
+        if (userAnswer === answer) {
+            this.updateLevel(sessionId, level, 6);
             return { quizResult: 'SUCCESS' };
         } else {
             return { quizResult: 'FAIL' };

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -7,6 +7,7 @@ import {
     PreviousProblemUnsolvedExeption,
 } from '../common/exception/errors';
 import { SandboxService } from 'src/sandbox/sandbox.service';
+import { CacheService } from 'src/common/cache/cache.service';
 
 @Injectable()
 export class QuizService {
@@ -14,7 +15,8 @@ export class QuizService {
     constructor(
         @InjectRepository(Quiz)
         private readonly quizRepository: Repository<Quiz>,
-        private readonly sandboxService: SandboxService
+        private readonly sandboxService: SandboxService,
+        private readonly cacheService: CacheService
     ) {
         this.initializeQuizData();
     }
@@ -76,13 +78,19 @@ export class QuizService {
         }
     }
 
-    async submitQuiz(quizId: number, containerPort: string) {
+    updateLevel(sessionId: string, prevLevel: number, newLevel: number) {
+        if (prevLevel < newLevel) {
+            this.cacheService.updateLevel(sessionId, newLevel);
+        }
+    }
+
+    async submitQuiz(quizId: number, sessionId: string, containerPort: string, level: number) {
         switch (quizId) {
             case 1:
-                return this.submitQuiz1(containerPort);
+                return this.submitQuiz1(sessionId, containerPort, level);
             case 4:
                 // 컨테이너 생성하기
-                return this.submitQuiz4(containerPort);
+                return this.submitQuiz4(sessionId, containerPort, level);
             // case 5:
             // 컨테이너 실행하기
             default:
@@ -90,26 +98,28 @@ export class QuizService {
         }
     }
 
-    private async submitQuiz1(containerPort: string) {
+    private async submitQuiz1(sessionId: string, containerPort: string, level: number) {
         const validImages = ['hello-world'];
         const images = await this.sandboxService.getUserImages(containerPort);
         const result = images.filter((image: Record<string, any>) =>
             validImages.includes(image.RepoTags[0]?.split(':')[0])
         );
         if (result.length > 0) {
+            this.updateLevel(sessionId, level, 2);
             return { quizResult: 'SUCCESS' };
         } else {
             return { quizResult: 'FAIL' };
         }
     }
 
-    private async submitQuiz4(containerPort: string) {
+    private async submitQuiz4(sessionId: string, containerPort: string, level: number) {
         const validImages = ['hello-world'];
         const containers = await this.sandboxService.getUserContainers(containerPort);
         const result = containers.filter((container: Record<string, any>) =>
             validImages.includes(container.Image)
         );
         if (result.length > 0) {
+            this.updateLevel(sessionId, level, 5);
             return { quizResult: 'SUCCESS' };
         } else {
             return { quizResult: 'FAIL' };

--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -160,7 +160,7 @@ export class SandboxService {
             renew: false,
             startTime: new Date(),
             // TODO: 현재 테스트를 위해 레벨을 임의로 조정중
-            level: 1,
+            level: 5,
         });
 
         this.logger.log(

--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -159,8 +159,8 @@ export class SandboxService {
             containerPort,
             renew: false,
             startTime: new Date(),
-            // TODO: 현재 테스트를 위해 레벨을 최대로 설정 중
-            level: 9,
+            // TODO: 현재 테스트를 위해 레벨을 임의로 조정중
+            level: 1,
         });
 
         this.logger.log(

--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -155,6 +155,7 @@ export class SandboxService {
 
         const newSessionId = randomUUID();
         this.cacheService.set(newSessionId, {
+            sessionId: newSessionId,
             containerId,
             containerPort,
             renew: false,

--- a/frontend/src/api/quiz.ts
+++ b/frontend/src/api/quiz.ts
@@ -28,9 +28,7 @@ const handleErrorResponse = (error: unknown, navigate: NavigateFunction) => {
 
 export const requestQuizData = async (quizNumber: string, navigate: NavigateFunction) => {
     try {
-        const response = await axios.get<Quiz>(
-            `${PROXY_URL}/api/quiz/${quizNumber}`
-        );
+        const response = await axios.get<Quiz>(`${PROXY_URL}/api/quiz/${quizNumber}`);
         return response.data;
     } catch (error) {
         return handleErrorResponse(error, navigate);
@@ -39,9 +37,7 @@ export const requestQuizData = async (quizNumber: string, navigate: NavigateFunc
 
 export const requestVisualizationData = async (navigate: NavigateFunction) => {
     try {
-        const response = await axios.get<Visualization>(
-            `${PROXY_URL}/api/sandbox/elements`
-        );
+        const response = await axios.get<Visualization>(`${PROXY_URL}/api/sandbox/elements`);
         return response.data;
     } catch (error) {
         return handleErrorResponse(error, navigate);
@@ -57,11 +53,39 @@ export const createHostContainer = async (navigate: NavigateFunction) => {
     }
 };
 
-export const requestSubmitResult = async (quizNumber: number, navigate: NavigateFunction) => {
+export const requestSubmitResult = async (
+    quizNumber: number,
+    userAnswer: string,
+    customQuizzes: number[],
+    navigate: NavigateFunction
+) => {
+    if (customQuizzes.includes(quizNumber)) {
+        return requestCustomQuizResult(quizNumber, userAnswer, navigate);
+    } else {
+        return requestDockerQuizResult(quizNumber, navigate);
+    }
+};
+
+const requestCustomQuizResult = async (
+    quizNumber: number,
+    userAnswer: string,
+    navigate: NavigateFunction
+) => {
     try {
-        const response = await axios.get<QuizResult>(
-            `${PROXY_URL}/api/quiz/${quizNumber}/submit`
-        );
+        const response = await axios.get<QuizResult>(`${PROXY_URL}/api/quiz/${quizNumber}/submit`, {
+            params: {
+                userAnswer,
+            },
+        });
+        return response.data;
+    } catch (error) {
+        return handleErrorResponse(error, navigate);
+    }
+};
+
+const requestDockerQuizResult = async (quizNumber: number, navigate: NavigateFunction) => {
+    try {
+        const response = await axios.get<QuizResult>(`${PROXY_URL}/api/quiz/${quizNumber}/submit`);
         return response.data;
     } catch (error) {
         return handleErrorResponse(error, navigate);
@@ -75,10 +99,7 @@ export const requestCommandResult = async (
     term?: Terminal
 ) => {
     try {
-        const response = await axios.post<string>(
-            `${PROXY_URL}/api/sandbox/command`,
-            { command }
-        );
+        const response = await axios.post<string>(`${PROXY_URL}/api/sandbox/command`, { command });
         return response.data;
     } catch (error) {
         if (customErrorCallback && term) {
@@ -92,7 +113,7 @@ export const requestCommandResult = async (
 
 export const requestQuizAccessability = async (quizId: number) => {
     try {
-        await axios.get(`${PROXY_URL}/api/quiz/${quizId}/access`)
+        await axios.get(`${PROXY_URL}/api/quiz/${quizId}/access`);
     } catch (error) {
         if (axios.isAxiosError(error)) {
             if (error.response && error.response.status === 403) {
@@ -102,4 +123,4 @@ export const requestQuizAccessability = async (quizId: number) => {
         throw error;
     }
     return true;
-}
+};

--- a/frontend/src/api/quiz.ts
+++ b/frontend/src/api/quiz.ts
@@ -3,6 +3,7 @@ import { Quiz, QuizResult } from '../types/quiz';
 import { Visualization } from '../types/visualization';
 import axios from 'axios';
 import { NavigateFunction } from 'react-router-dom';
+import { CUSTOM_QUIZZES } from '../constant/quiz';
 
 const PROXY_HOST = import.meta.env.VITE_PROXY_HOST;
 const PROXY_PORT = import.meta.env.VITE_PROXY_PORT;
@@ -56,10 +57,9 @@ export const createHostContainer = async (navigate: NavigateFunction) => {
 export const requestSubmitResult = async (
     quizNumber: number,
     userAnswer: string,
-    customQuizzes: number[],
     navigate: NavigateFunction
 ) => {
-    if (customQuizzes.includes(quizNumber)) {
+    if (CUSTOM_QUIZZES.includes(quizNumber)) {
         return requestCustomQuizResult(quizNumber, userAnswer, navigate);
     } else {
         return requestDockerQuizResult(quizNumber, navigate);

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -2,13 +2,18 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { requestQuizAccessability, requestSubmitResult } from '../../api/quiz';
 
-const QuizButtons = ({ quizId }: { quizId: number }) => {
+type QuizButtonsProps = {
+    quizId: number;
+    answer: string;
+    customQuizzes: number[];
+};
+
+const QuizButtons = ({ quizId, answer, customQuizzes }: QuizButtonsProps) => {
     const [submitResult, setSubmitResult] = useState('default');
     const navigate = useNavigate();
 
     const handleSubmitButtonClick = async () => {
-        // TODO: 퀴즈 번호에 따라 request 쿼리 파라미터에 값이 추가될 수 있다.
-        const submitResponse = await requestSubmitResult(quizId, navigate);
+        const submitResponse = await requestSubmitResult(quizId, answer, customQuizzes, navigate);
         if (!submitResponse) {
             return;
         }

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -5,15 +5,14 @@ import { requestQuizAccessability, requestSubmitResult } from '../../api/quiz';
 type QuizButtonsProps = {
     quizId: number;
     answer: string;
-    customQuizzes: number[];
 };
 
-const QuizButtons = ({ quizId, answer, customQuizzes }: QuizButtonsProps) => {
+const QuizButtons = ({ quizId, answer }: QuizButtonsProps) => {
     const [submitResult, setSubmitResult] = useState('default');
     const navigate = useNavigate();
 
     const handleSubmitButtonClick = async () => {
-        const submitResponse = await requestSubmitResult(quizId, answer, customQuizzes, navigate);
+        const submitResponse = await requestSubmitResult(quizId, answer, navigate);
         if (!submitResponse) {
             return;
         }

--- a/frontend/src/components/quiz/QuizInputBox.tsx
+++ b/frontend/src/components/quiz/QuizInputBox.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
-const QuizInputBox = () => {
-    const [answer, setAnswer] = useState('');
+type QuizInputBoxProps = {
+    answer: string;
+    setAnswer: React.Dispatch<React.SetStateAction<string>>;
+};
 
+const QuizInputBox = ({ answer, setAnswer }: QuizInputBoxProps) => {
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setAnswer(e.target.value);
     };

--- a/frontend/src/components/quiz/QuizSubmitArea.tsx
+++ b/frontend/src/components/quiz/QuizSubmitArea.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import QuizButtons from './QuizButtons';
+import QuizInputBox from './QuizInputBox';
+
+type QuizSubmitAreaProps = {
+    quizId: number;
+};
+
+const QuizSubmitArea = ({ quizId }: QuizSubmitAreaProps) => {
+    const [answer, setAnswer] = useState('');
+    const customQuizzes = [2, 5, 6, 7];
+
+    return (
+        <>
+            {customQuizzes.includes(quizId) ? (
+                <QuizInputBox answer={answer} setAnswer={setAnswer} />
+            ) : null}
+            <QuizButtons quizId={quizId} answer={answer} customQuizzes={customQuizzes} />
+        </>
+    );
+};
+
+export default QuizSubmitArea;

--- a/frontend/src/components/quiz/QuizSubmitArea.tsx
+++ b/frontend/src/components/quiz/QuizSubmitArea.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import QuizButtons from './QuizButtons';
 import QuizInputBox from './QuizInputBox';
+import { CUSTOM_QUIZZES } from '../../constant/quiz';
 
 type QuizSubmitAreaProps = {
     quizId: number;
@@ -8,14 +9,13 @@ type QuizSubmitAreaProps = {
 
 const QuizSubmitArea = ({ quizId }: QuizSubmitAreaProps) => {
     const [answer, setAnswer] = useState('');
-    const customQuizzes = [2, 5, 6, 7];
 
     return (
         <>
-            {customQuizzes.includes(quizId) ? (
+            {CUSTOM_QUIZZES.includes(quizId) ? (
                 <QuizInputBox answer={answer} setAnswer={setAnswer} />
             ) : null}
-            <QuizButtons quizId={quizId} answer={answer} customQuizzes={customQuizzes} />
+            <QuizButtons quizId={quizId} answer={answer} />
         </>
     );
 };

--- a/frontend/src/components/quizpages/InputBoxQuizPage.tsx
+++ b/frontend/src/components/quizpages/InputBoxQuizPage.tsx
@@ -4,10 +4,9 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import DockerVisualization from '../visualization/DockerVisualization';
 import { Quiz } from '../../types/quiz';
 import QuizDescription from '../quiz/QuizDescription';
-import QuizButtons from '../quiz/QuizButtons';
 import XTerminal from '../quiz/XTerminal';
-import QuizInputBox from '../quiz/QuizInputBox';
 import useDockerVisualization from '../../hooks/useDockerVisualization';
+import QuizSubmitArea from '../quiz/QuizSubmitArea';
 
 const InputBoxQuizPage = () => {
     const navigate = useNavigate();
@@ -51,8 +50,7 @@ const InputBoxQuizPage = () => {
                 />
             </section>
             <XTerminal updateVisualizationData={updateVisualizationData} />
-            <QuizInputBox />
-            <QuizButtons quizId={+quizNum} />
+            <QuizSubmitArea quizId={+quizNum} />
         </div>
     );
 };

--- a/frontend/src/components/quizpages/TextAreaQuizPage.tsx
+++ b/frontend/src/components/quizpages/TextAreaQuizPage.tsx
@@ -5,8 +5,8 @@ import { requestQuizData } from '../../api/quiz';
 import DockerVisualization from '../visualization/DockerVisualization';
 import QuizDescription from '../quiz/QuizDescription';
 import XTerminal from '../quiz/XTerminal';
-import QuizButtons from '../quiz/QuizButtons';
 import useDockerVisualization from '../../hooks/useDockerVisualization';
+import QuizSubmitArea from '../quiz/QuizSubmitArea';
 
 const TextAreaQuizPage = () => {
     const navigate = useNavigate();
@@ -51,7 +51,7 @@ const TextAreaQuizPage = () => {
                 />
             </section>
             <XTerminal updateVisualizationData={updateVisualizationData} />
-            <QuizButtons quizId={+quizNum} />
+            <QuizSubmitArea quizId={+quizNum} />
         </div>
     );
 };

--- a/frontend/src/constant/quiz.ts
+++ b/frontend/src/constant/quiz.ts
@@ -1,0 +1,1 @@
+export const CUSTOM_QUIZZES: readonly number[] = [2, 5, 6, 7];


### PR DESCRIPTION
## 작업 개요

- closes #200
- closes #206

## 작업 상세 내용

- [x]  퀴즈 정답 제출시 사용자 레벨 상승 기능 구현
- [x]  컨테이너 실행하기 퀴즈 채점 기능 구현
    - [x]  /api/quiz/:id/submit 경로에 userAnswer 쿼리 파라미터 추가
- [x]  프론트에서 문제 유형에 따라 다른 형태의 요청을 프록시 서버에 보내기

### 레벨 상승 기능

- image 가져오기 퀴즈를 풀면 1에서 2로 증가

![image](https://github.com/user-attachments/assets/9100df98-3ca8-4ff1-9b2e-498a79057ea4)


### 컨테이너 실행하기 채점 결과

- 임의로 정의한 'start' 정답을 맞추는 경우 SUCCESS

![image](https://github.com/user-attachments/assets/ff4dbf4a-bd62-4d18-828d-82de1131def6)

### QuizSubmitArea 컴포넌트

```tsx
const QuizSubmitArea = ({ quizId }: QuizSubmitAreaProps) => {
    const [answer, setAnswer] = useState('');
    const customQuizzes = [2, 5, 6, 7];

    return (
        <>
            {customQuizzes.includes(quizId) ? (
                <QuizInputBox answer={answer} setAnswer={setAnswer} />
            ) : null}
            <QuizButtons quizId={quizId} answer={answer} customQuizzes={customQuizzes} />
        </>
    );
};

```

## 문제점 혹은 고민

- InputBoxQuizPage와 TextAreaQuizPage가 이제는 동일한 만큼 하나의 퀴즈 페이지로 합치고 /quiz/:id 처럼 파라미터를 사용하는 형태로 App.tsx의 라우팅 부분을 업데이트 하려고 했습니다.
- 하지만 그 과정에서 lint 에러가 발생해서 롤백한 상태입니다.
- `const { quizNum } = useParams()` 와 같은 형태로 사용하려 했는데, quizNum이 undefined인 경우에 대한 처리가 필요해서 현재 연구중입니다.