### PR TITLE
프론트엔드 개발 서버와 백엔드 개발 서버 한번에 띄우기

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "dotenvx run -f ../.env.production -- nest start",
-    "start:dev": "dotenvx run -f ../.env -- nest start --watch",
+    "start:dev": "dotenvx run -f ../.env -- nest start --watch --preserveWatchOutput",
     "start:debug": "dotenvx run -f ../.env -- nest start --debug",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/frontend/src/api/quiz.ts
+++ b/frontend/src/api/quiz.ts
@@ -4,10 +4,6 @@ import { Visualization } from '../types/visualization';
 import axios from 'axios';
 import { NavigateFunction } from 'react-router-dom';
 
-const PROXY_HOST = import.meta.env.VITE_PROXY_HOST;
-const PROXY_PORT = import.meta.env.VITE_PROXY_PORT;
-const PROXY_URL = `http://${PROXY_HOST}:${PROXY_PORT}`;
-
 const handleErrorResponse = (error: unknown, navigate: NavigateFunction) => {
     if (axios.isAxiosError(error)) {
         if (error.response) {
@@ -28,9 +24,7 @@ const handleErrorResponse = (error: unknown, navigate: NavigateFunction) => {
 
 export const requestQuizData = async (quizNumber: string, navigate: NavigateFunction) => {
     try {
-        const response = await axios.get<Quiz>(
-            `${PROXY_URL}/api/quiz/${quizNumber}`
-        );
+        const response = await axios.get<Quiz>(`/api/quiz/${quizNumber}`);
         return response.data;
     } catch (error) {
         return handleErrorResponse(error, navigate);
@@ -39,9 +33,7 @@ export const requestQuizData = async (quizNumber: string, navigate: NavigateFunc
 
 export const requestVisualizationData = async (navigate: NavigateFunction) => {
     try {
-        const response = await axios.get<Visualization>(
-            `${PROXY_URL}/api/sandbox/elements`
-        );
+        const response = await axios.get<Visualization>(`/api/sandbox/elements`);
         return response.data;
     } catch (error) {
         return handleErrorResponse(error, navigate);
@@ -50,7 +42,7 @@ export const requestVisualizationData = async (navigate: NavigateFunction) => {
 
 export const createHostContainer = async (navigate: NavigateFunction) => {
     try {
-        await axios.post(`${PROXY_URL}/api/sandbox/start`);
+        await axios.post(`/api/sandbox/start`);
         return true;
     } catch (error) {
         return handleErrorResponse(error, navigate);
@@ -59,9 +51,7 @@ export const createHostContainer = async (navigate: NavigateFunction) => {
 
 export const requestSubmitResult = async (quizNumber: number, navigate: NavigateFunction) => {
     try {
-        const response = await axios.get<QuizResult>(
-            `${PROXY_URL}/api/quiz/${quizNumber}/submit`
-        );
+        const response = await axios.get<QuizResult>(`/api/quiz/${quizNumber}/submit`);
         return response.data;
     } catch (error) {
         return handleErrorResponse(error, navigate);
@@ -75,10 +65,7 @@ export const requestCommandResult = async (
     term?: Terminal
 ) => {
     try {
-        const response = await axios.post<string>(
-            `${PROXY_URL}/api/sandbox/command`,
-            { command }
-        );
+        const response = await axios.post<string>(`/api/sandbox/command`, { command });
         return response.data;
     } catch (error) {
         if (customErrorCallback && term) {
@@ -92,7 +79,7 @@ export const requestCommandResult = async (
 
 export const requestQuizAccessability = async (quizId: number) => {
     try {
-        await axios.get(`${PROXY_URL}/api/quiz/${quizId}/access`)
+        await axios.get(`/api/quiz/${quizId}/access`);
     } catch (error) {
         if (axios.isAxiosError(error)) {
             if (error.response && error.response.status === 403) {
@@ -102,4 +89,4 @@ export const requestQuizAccessability = async (quizId: number) => {
         throw error;
     }
     return true;
-}
+};

--- a/frontend/src/api/timer.ts
+++ b/frontend/src/api/timer.ts
@@ -1,13 +1,10 @@
 import axios from 'axios';
 import { ExpirationTime } from '../types/timer';
 
-const PROXY_HOST = import.meta.env.VITE_PROXY_HOST;
-const PROXY_PORT = import.meta.env.VITE_PROXY_PORT;
-
 export const requestExpriationTime = async (): Promise<ExpirationTime | object> => {
     try {
         const response = await axios.get<ExpirationTime>(
-            `http://${PROXY_HOST}:${PROXY_PORT}/api/sandbox/endDate`
+            `/api/sandbox/endDate`
         );
         console.log('session Time: ', response.data);
         return response.data;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,11 +4,20 @@ import react from '@vitejs/plugin-react-swc';
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '../');
+
+    const apiHost = env.VITE_PROXY_HOST || 'localhost';
+    const apiPort = env.VITE_PROXY_PORT || '3000';
+    const apiUrl = `http://${apiHost}:${apiPort}`;
+
     return {
         plugins: [react()],
-        envDir: '../',
-        define: {
-            'import.meta.env': JSON.stringify(env),
+        server: {
+            proxy: {
+                '/api': {
+                    target: apiUrl,
+                    changeOrigin: true,
+                },
+            },
         },
     };
 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "pnpm -F frontend build && pnpm -F backend start",
+    "dev": "concurrently --raw \"pnpm -F backend start:dev\" \"pnpm -F frontend dev\"",
     "lint": "eslint . ",
     "prettier": "prettier --write ."
   },
@@ -14,6 +15,7 @@
     "@eslint/js": "^9.14.0",
     "@types/eslint__js": "^8.42.3",
     "@typescript-eslint/eslint-plugin": "^8.13.0",
+    "concurrently": "^9.1.0",
     "eslint": "^9.14.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.37.2",


### PR DESCRIPTION
## 작업 개요

closes #241 

## 작업 상세 내용

### Vite Proxy를 사용하여 백엔드 서버 찾기
기존에는 프론트엔드 코드 상에서 axios로 요청을 보낼 때 host 주소를 명시했었습니다.
.env 파일에 VITE_PROXY_HOST와 PORT 값을 두고, 이를 가져와서 URL을 만들었었죠.
해당 코드는 삭제되었습니다. host 주소 없이, API endpoint만 적습니다.
그러면 Vite가 .env에 명시된 주소를 가지고 API 요청을 프록시해줍니다. 자세한 내용은 하단 개발 기록 참고해주세요.
**정리) .env에 있던 샌드박스 프록시 호스트와 포트 번호는 필요합니다. axios로 요청 보낼 땐 env값 가져올 필요 없습니다.**

### Concurrently로 서버 2개 한번에 실행하기
`vite` 명령어는 프론트엔드 개발 서버를 열고, `nest start --watch`는 백엔드 개발 서버를 열죠.
원래는 터미널 두 개 띄우고 각각 다른 명령어를 입력하여 서버를 실행시켜야 했습니다.
concurrently라는 npm 패키지는 같은 터미널에서 서버 2개를 동시에 실행시키게 도와줍니다.

## 참고자료(선택)
[개발 기록 Wiki](https://github.com/boostcampwm-2024/web34-LearnDocker/wiki/%EA%B0%9C%EB%B0%9C%EA%B8%B0%EB%A1%9D_J114%EB%B0%95%EC%84%B8%ED%99%98_4%EC%A3%BC6%EC%9D%BC%EC%B0%A8_%EA%B0%9C%EB%B0%9C%EC%9A%A9-React--Vite-%EC%84%9C%EB%B2%84%EC%99%80-Nestjs-%EC%84%9C%EB%B2%84-%EB%8F%99%EC%8B%9C%EC%97%90-%EB%9D%84%EC%9A%B0%EA%B8%B0)
## 문제점 혹은 고민(선택)