### PR TITLE
퀴즈 문제 구현, 퀴즈 2,3,6,7,8,9 채점 구현

### DIFF
--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -42,7 +42,7 @@ export class QuizService {
                 content:
                     '로컬 시스템에 저장된 Docker 이미지들을 확인해볼까요?\n\n' +
                     '1. docker images 명령어를 사용하여 현재 시스템에 있는 모든 Docker 이미지를 조회하세요.\n' +
-                    '2. 명령어 실행 후 출력된 결과에서 hello-world 이미지의 Image ID 앞 4자리를 입력하세요.\n\n' +
+                    '2. 명령어 실행 후 출력된 결과에서 hello-world 이미지의 Image ID 최소 앞 4자리를 입력하세요.\n\n' +
                     '힌트: 이미지 목록을 확인하는 명령어는 별도의 인자가 필요하지 않습니다.',
             },
             {
@@ -91,7 +91,7 @@ export class QuizService {
                 content:
                     '실행 중이거나 중지된 모든 컨테이너를 확인해봅시다.\n\n' +
                     '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n' +
-                    '2. 출력된 결과에서 hello-world2 컨테이너의 ID 앞 4자리를 입력하세요.\n\n' +
+                    '2. 출력된 결과에서 hello-world2 컨테이너의 ID 최소 앞 4자리를 입력하세요.\n\n' +
                     '힌트: docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.',
             },
             {
@@ -202,7 +202,7 @@ export class QuizService {
     ) {
         // TODO: 로컬레지스트리 사용시 이미지ID 동일한지 확인 필요
         // 동일하면 로직 수정 필요
-        if (userAnswer?.length !== 4) {
+        if (!userAnswer || userAnswer.length < 4) {
             return { quizResult: 'FAIL' };
         }
 
@@ -277,7 +277,7 @@ export class QuizService {
         userAnswer: string | undefined,
         level: number
     ) {
-        if (userAnswer?.length !== 4) {
+        if (!userAnswer || userAnswer.length < 4) {
             return { quizResult: 'FAIL' };
         }
 

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -26,39 +26,95 @@ export class QuizService {
 
         const quizzeData = [
             {
+                //TODO: pull 명령어나 이미지 명령어의 경우 앞에 registry를 붙여야 된다고 알려주기
                 id: 1,
                 title: 'Docker Image 가져오기',
                 content:
-                    'Docker의 첫 걸음을 시작해볼까요?\n가장 먼저 해볼 것은 hello-world 이미지를 가져오는 것입니다.\n적절한 Docker 명령어를 사용하여 이미지를 다운로드해보세요\n',
+                    'Docker의 첫 걸음을 시작해볼까요?\n' +
+                    'Docker Hub에서 제공하는 hello-world 이미지를 가져와보세요.\n\n' +
+                    '1. docker pull 명령어를 사용하여 hello-world 이미지를 다운로드하세요.\n' +
+                    '2. 이미지가 성공적으로 다운로드되면 자동으로 로컬 시스템에 저장됩니다.\n\n' +
+                    '힌트: docker pull <이미지명> 형식으로 명령어를 작성하세요.',
             },
             {
                 id: 2,
                 title: 'Docker Image 목록 확인하기',
-                content: '',
+                content:
+                    '로컬 시스템에 저장된 Docker 이미지들을 확인해볼까요?\n\n' +
+                    '1. docker images 명령어를 사용하여 현재 시스템에 있는 모든 Docker 이미지를 조회하세요.\n' +
+                    '2. 명령어 실행 후 출력된 결과에서 hello-world 이미지의 Image ID 앞 4자리를 입력하세요.\n\n' +
+                    '힌트: 이미지 목록을 확인하는 명령어는 별도의 인자가 필요하지 않습니다.',
             },
             {
                 id: 3,
                 title: 'Docker Image 삭제하기',
-                content: '',
+                content:
+                    '더 이상 필요하지 않은 Docker 이미지를 삭제하는 방법을 알아봅시다.\n\n' +
+                    '1. docker rmi 명령어를 사용하여 hello-world 이미지를 삭제하세요.\n' +
+                    '2. 삭제 후 docker images 명령어로 이미지가 정상적으로 삭제되었는지 확인하세요.\n\n' +
+                    '힌트: docker rmi <이미지명> 형식으로 명령어를 작성하세요.',
             },
             {
                 id: 4,
                 title: 'Container 생성하기',
-                content: '',
+                content:
+                    'Docker 이미지를 기반으로 컨테이너를 생성해봅시다.\n\n' +
+                    '1. docker create 명령어를 사용하여 hello-world 이미지로부터 컨테이너를 생성하세요.\n\n' +
+                    '힌트: docker create <이미지명> 형식으로 명령어를 작성하세요.',
             },
+            //TODO: hello-world, hello-world2(가제) 이미지를 커스텀 해서 터미널에 정답이 나오게 하기
             {
                 id: 5,
                 title: 'Container 실행하기',
-                content: '',
+                content:
+                    '생성된 컨테이너를 실행해보겠습니다.\n\n' +
+                    '1. docker start 명령어를 사용하여 이전 단계에서 생성한 컨테이너를 실행하세요.\n' +
+                    '2. 컨테이너 ID나 이름을 사용하여 실행할 수 있습니다.\n' +
+                    '3. 실행 후 터미널에 표시되는 "answer: " 다음에 나오는 값을 입력해주세요.\n\n' +
+                    '힌트: docker start <컨테이너ID> 형식으로 명령어를 작성하세요.\n' +
+                    '힌트: 컨테이너ID 전부 적을 필요는 없습니다.',
             },
+            // TODO: hello-world2는 가제 수정 필요
             {
                 id: 6,
                 title: 'Container 생성 및 실행하기',
-                content: '',
+                content:
+                    '컨테이너의 생성과 실행을 한 번에 수행해봅시다.\n\n' +
+                    '1. docker run 명령어를 사용하여 hello-world2 이미지로 컨테이너를 생성하고 실행하세요.\n' +
+                    '2. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n' +
+                    '3. 실행 후 터미널에 표시되는 "answer: " 다음에 나오는 값을 입력해주세요.\n\n' +
+                    '힌트: docker run <이미지명> 형식으로 명령어를 작성하세요.',
             },
-            { id: 7, title: 'Container 목록 확인하기', content: '' },
-            { id: 8, title: 'Container 중지하기', content: '' },
-            { id: 9, title: 'Container 삭제하기', content: '' },
+            {
+                id: 7,
+                title: 'Container 목록 확인하기',
+                content:
+                    '실행 중이거나 중지된 모든 컨테이너를 확인해봅시다.\n\n' +
+                    '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n' +
+                    '2. 출력된 결과에서 hello-world2 컨테이너의 ID 앞 4자리를 입력하세요.\n\n' +
+                    '힌트: docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.',
+            },
+            {
+                id: 8,
+                title: 'Container 중지하기',
+                content:
+                    '실행 중인 컨테이너를 중지해보겠습니다.\n\n' +
+                    '1. docker stop 명령어를 사용하여 실행 중인 모든 컨테이너를 중지하세요.\n' +
+                    '2. 컨테이너가 중지되면 상태가 Exited로 변경됩니다.\n\n' +
+                    '힌트: docker stop <컨테이너ID> 형식으로 명령어를 작성하세요.\n' +
+                    '힌트: 컨테이너ID 전부 적을 필요는 없습니다.',
+            },
+            {
+                id: 9,
+                title: 'Container 삭제하기',
+                content:
+                    '더 이상 필요하지 않은 컨테이너를 삭제해봅시다.\n\n' +
+                    '1. docker rm 명령어를 사용하여 모든 컨테이너를 삭제하세요.\n' +
+                    '2. 컨테이너가 실행 중인 경우 먼저 중지한 후 삭제해야 합니다.\n' +
+                    '3. 삭제 후 docker ps -a로 확인해보세요.\n\n' +
+                    '힌트: docker rm <컨테이너ID> 형식으로 명령어를 작성하세요.\n' +
+                    '힌트: 컨테이너ID 전부 적을 필요는 없습니다.',
+            },
         ];
 
         await this.quizRepository.insert(quizzeData);
@@ -93,13 +149,32 @@ export class QuizService {
     ) {
         switch (quizId) {
             case 1:
+                // 이미지 가져오기
                 return this.submitQuiz1(sessionId, containerPort, level);
+            case 2:
+                //이미지 목록 확인하기
+                return this.submitQuiz2(sessionId, containerPort, userAnswer, level);
+            case 3:
+                //이미지 삭제 하기
+                return this.submitQuiz3(sessionId, containerPort, level);
             case 4:
                 // 컨테이너 생성하기
                 return this.submitQuiz4(sessionId, containerPort, level);
             case 5:
                 //컨테이너 실행하기
                 return this.submitQuiz5(sessionId, userAnswer, level);
+            case 6:
+                //컨테이너 생성및 실행하기
+                return this.submitQuiz6(sessionId, userAnswer, level);
+            case 7:
+                //컨테이너 목록 확인하기
+                return this.submitQuiz7(sessionId, containerPort, userAnswer, level);
+            case 8:
+                //컨테이너 중지하기
+                return this.submitQuiz8(sessionId, containerPort, level);
+            case 9:
+                //컨테이너 삭제하기
+                return this.submitQuiz9(sessionId, containerPort, level);
             default:
                 throw new MethodNotAllowedException(`${quizId}번 퀴즈는 아직 채점할 수 없습니다.`);
         }
@@ -119,11 +194,51 @@ export class QuizService {
         }
     }
 
-    private async submitQuiz4(sessionId: string, containerPort: string, level: number) {
+    private async submitQuiz2(
+        sessionId: string,
+        containerPort: string,
+        userAnswer: string | undefined,
+        level: number
+    ) {
+        // TODO: 로컬레지스트리 사용시 이미지ID 동일한지 확인 필요
+        // 동일하면 로직 수정 필요
+        if (userAnswer?.length !== 4) {
+            return { quizResult: 'FAIL' };
+        }
+
+        const imageIdPrefix = 'sha256:';
+        const images = await this.sandboxService.getUserImages(containerPort);
+        const result = images.filter((image: Record<string, any>) =>
+            image.Id.startsWith(`${imageIdPrefix}${userAnswer}`)
+        );
+
+        if (result.length > 0) {
+            this.updateLevel(sessionId, level, 3);
+            return { quizResult: 'SUCCESS' };
+        } else {
+            return { quizResult: 'FAIL' };
+        }
+    }
+
+    private async submitQuiz3(sessionId: string, containerPort: string, level: number) {
         const validImages = ['hello-world'];
+        const images = await this.sandboxService.getUserImages(containerPort);
+        const result = images.filter((image: Record<string, any>) =>
+            validImages.includes(image.RepoTags[0]?.split(':')[0])
+        );
+        if (result.length === 0) {
+            this.updateLevel(sessionId, level, 4);
+            return { quizResult: 'SUCCESS' };
+        } else {
+            return { quizResult: 'FAIL' };
+        }
+    }
+
+    private async submitQuiz4(sessionId: string, containerPort: string, level: number) {
+        const validImage = ['hello-world'];
         const containers = await this.sandboxService.getUserContainers(containerPort);
         const result = containers.filter((container: Record<string, any>) =>
-            validImages.includes(container.Image)
+            validImage.includes(container.Image)
         );
         if (result.length > 0) {
             this.updateLevel(sessionId, level, 5);
@@ -138,6 +253,69 @@ export class QuizService {
 
         if (userAnswer === answer) {
             this.updateLevel(sessionId, level, 6);
+            return { quizResult: 'SUCCESS' };
+        } else {
+            return { quizResult: 'FAIL' };
+        }
+    }
+
+    private async submitQuiz6(sessionId: string, userAnswer: string | undefined, level: number) {
+        // TODO: 커스텀 이미지 만들고 answer 수정해야함
+        const answer = 'hello-world';
+
+        if (userAnswer === answer) {
+            this.updateLevel(sessionId, level, 7);
+            return { quizResult: 'SUCCESS' };
+        } else {
+            return { quizResult: 'FAIL' };
+        }
+    }
+
+    private async submitQuiz7(
+        sessionId: string,
+        containerPort: string,
+        userAnswer: string | undefined,
+        level: number
+    ) {
+        if (userAnswer?.length !== 4) {
+            return { quizResult: 'FAIL' };
+        }
+
+        const containers = await this.sandboxService.getUserContainers(containerPort);
+        const result = containers.filter((container: Record<string, any>) =>
+            container.Id.startsWith(userAnswer)
+        );
+
+        if (result.length > 0) {
+            this.updateLevel(sessionId, level, 8);
+            return { quizResult: 'SUCCESS' };
+        } else {
+            return { quizResult: 'FAIL' };
+        }
+    }
+
+    private async submitQuiz8(sessionId: string, containerPort: string, level: number) {
+        const containers = await this.sandboxService.getUserContainers(containerPort);
+        if (containers.length === 0) {
+            return { quizResult: 'FAIL' };
+        }
+
+        const result = containers.every(
+            (container: Record<string, any>) => container.State === 'exited'
+        );
+        if (result) {
+            this.updateLevel(sessionId, level, 9);
+            return { quizResult: 'SUCCESS' };
+        } else {
+            return { quizResult: 'FAIL' };
+        }
+    }
+
+    private async submitQuiz9(sessionId: string, containerPort: string, level: number) {
+        const containers = await this.sandboxService.getUserContainers(containerPort);
+
+        if (containers.length === 0) {
+            this.updateLevel(sessionId, level, 10);
             return { quizResult: 'SUCCESS' };
         } else {
             return { quizResult: 'FAIL' };

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -26,7 +26,25 @@ const QuizButtons = ({ quizId, answer }: QuizButtonsProps) => {
         // TODO: submitResult의 상태에 따라 모달창을 띄워줘야 한다.
         // 아래 console.log는 테스트 용도, 나중에 삭제해야 함
         // 여기서 해줄 작업은 없고, 아래 jsx를 return해줄 때 모달창 띄우는 코드를 추가해야 할 듯 합니다.
+
+        // default가 나오는 이유는 setState가 비동기적으로 실행 되기 때문입니다.
+        // useEffect를 사용하거나 바뀐값을 변수에 담고 변수값을 console.log로 보여줘도 될 것 같아요
+        // 일단 아직 결정된 사항이 없어서 주석에 적기만 하겠습니다.
         console.log(submitResult);
+    };
+
+    const handlePrevButtonClick = async () => {
+        if (quizId === 1) {
+            alert('처음 문제입니다');
+            return;
+        }
+
+        if (quizId === 4) {
+            navigate('/what-is-container-lifecycle');
+            return;
+        }
+
+        navigate(`/quiz/${quizId - 1}`);
     };
 
     const handleNextButtonClick = async () => {
@@ -36,7 +54,7 @@ const QuizButtons = ({ quizId, answer }: QuizButtonsProps) => {
             return;
         }
 
-        if (quizId > 9) {
+        if (quizId > 8) {
             alert('마지막 문제입니다');
             return;
         }
@@ -49,10 +67,12 @@ const QuizButtons = ({ quizId, answer }: QuizButtonsProps) => {
         navigate(`/quiz/${quizId + 1}`);
     };
 
-    // TODO: 이전. 다음버튼에 이벤트 추가가 필요합니다.
     return (
         <section className='w-[85%] flex justify-end'>
-            <button className='text-lg text-white rounded-lg bg-gray-300 hover:bg-gray-400 py-2 px-4 my-4 mx-1'>
+            <button
+                className='text-lg text-white rounded-lg bg-gray-300 hover:bg-gray-400 py-2 px-4 my-4 mx-1'
+                onClick={handlePrevButtonClick}
+            >
                 이전
             </button>
             <button


### PR DESCRIPTION
## 작업 개요
<details>
<summary>해결된 이슈 목록 </summary>

- resolve #24 
- resolve #32 
- resolve #40 
- resolve #48 
- resolve #64 
- resolve #66 
- resolve #67 
- resolve #80 
- resolve #82 
- resolve #83 
- resolve #56 
- resolve #58 
- resolve #59 
- resolve #72 
- resolve #74 
- resolve #75 
- resolve #130 
- resolve #189
- resolve #190
- resolve #191 
- resovle #192  
- resolve #193 
- resolve #198 
- resolve #202
- resolve #207
- resolve #210 
- resolve #213 
- resolve #214 
- resolve #219 
- resolve #220 
- resolve #221 
</details>

## 작업 상세 내용
### 문제 내용 구현
  - 간단한 문제를 구현했습니다.
  - 이렇게 문제틀을 가져갈까 생각중입니다
  - 언제든지 수정, 추가 가능합니다
### 2,3,6,7,8,9 문제 채점 구현
- 로컬레지스트리 문제, 커스텀 이미지 문제 때문에 TODO가 많은 상태입니다.
- 두 문제가 해결되거나 결정 되면 TODO 해결하겠습니다.
### 이전 문제 버튼 추가
- 따로 유효성 검사 없이 이전 문제로 이동 가능하게 했습니다.

## 문제점 혹은 고민(선택)
### hello-world의 문제
- hello-world의 경우 실행하면 stdout으로 문자열을 출력하고 종료됩니다
- 이런 특이성 때문에 몇몇 문제가 발생합니다.
#### 1. 컨테이너 중지 문제가 필요없어짐
- 실행 되면 알아서 중지 되기 때문에 컨테이너 중지 문제에서 보여줄 것이 없습니다.
- 바로 채점하기 누르면 통과가 됩니다.
#### 2. docker run과 start가 차이가 남
![run_start_차이](https://github.com/user-attachments/assets/08acebd7-0ad1-402b-a1d6-66b2cbffa8b8)
- start을 할때 -a 옵션으로 attach를 해줘야 stdout으로 출력됩니다.

### 해결법?
- 커스텀 이미지를 만들때 종료가 안 되도록 만들면 될 것 같습니다.