### PR TITLE
서버 리소스 관리를 위한 태스크 작업

### DIFF
--- a/backend/src/common/auth/auth.service.ts
+++ b/backend/src/common/auth/auth.service.ts
@@ -11,7 +11,7 @@ export class AuthService {
         if (sessionId == null) {
             throw new InvalidSessionException();
         }
-        const session =  this.cacheService.get(sessionId);
+        const session = this.cacheService.get(sessionId);
         if (session == null) {
             throw new InvalidSessionException();
         }
@@ -21,9 +21,10 @@ export class AuthService {
         return session;
     }
 
-    throwIfSessionIsValid(sessionId?: string) {
+    throwIfSessionIsValid(hashedSessionID: string, sessionId?: string) {
         try {
-            this.validateSession(sessionId)
+            if (sessionId) this.validateSession(sessionId);
+            else this.validateSession(hashedSessionID);
             throw new SessionAlreadyAssignedException();
         } catch (error) {
             if (!(error instanceof InvalidSessionException)) {

--- a/backend/src/common/auth/auth.service.ts
+++ b/backend/src/common/auth/auth.service.ts
@@ -21,10 +21,10 @@ export class AuthService {
         return session;
     }
 
-    throwIfSessionIsValid(hashedSessionID: string, sessionId?: string) {
+    throwIfSessionIsValid(hashedIpAddress: string, sessionId?: string) {
         try {
             if (sessionId) this.validateSession(sessionId);
-            else this.validateSession(hashedSessionID);
+            else this.validateSession(hashedIpAddress);
             throw new SessionAlreadyAssignedException();
         } catch (error) {
             if (!(error instanceof InvalidSessionException)) {

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -7,7 +7,8 @@ import { HideInProduction } from '../common/decorator/hide-in-production.decorat
 import { AuthGuard } from '../common/auth/auth.guard';
 import { AuthService } from '../common/auth/auth.service';
 import { RequestWithSession } from '../common/types/request';
-
+import { SessionAlreadyAssignedException } from 'src/common/exception/errors';
+import { getHashValueFromIP } from '../sandbox/utils';
 @Controller('sandbox')
 export class SandboxController {
     constructor(
@@ -36,10 +37,17 @@ export class SandboxController {
     @Post('start')
     async assignContainer(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
         const sessionId = req.cookies['sid'];
-        this.authService.throwIfSessionIsValid(sessionId);
-
-        const newSessionId = await this.sandboxService.assignContainer();
-        res.cookie('sid', newSessionId, { httpOnly: true, maxAge: SESSION_DURATION });
+        const ipAddress = req.ip as string;
+        const hashedSessionID = getHashValueFromIP(ipAddress);
+        try {
+            this.authService.throwIfSessionIsValid(hashedSessionID, sessionId);
+            const newSessionId = await this.sandboxService.assignContainer(ipAddress);
+            res.cookie('sid', newSessionId, { httpOnly: true, maxAge: SESSION_DURATION });
+        } catch (error) {
+            if (error instanceof SessionAlreadyAssignedException) {
+                res.cookie('sid', hashedSessionID, { httpOnly: true, maxAge: SESSION_DURATION });
+            }
+        }
     }
 
     @Get('hostStatus')

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -46,7 +46,9 @@ export class SandboxController {
         } catch (error) {
             if (error instanceof SessionAlreadyAssignedException) {
                 res.cookie('sid', hashedSessionID, { httpOnly: true, maxAge: SESSION_DURATION });
+                return;
             }
+            throw error;
         }
     }
 

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -57,6 +57,14 @@ export class SandboxController {
         return { endDate };
     }
 
+    @Delete('release')
+    @UseGuards(AuthGuard)
+    releaseUserSession(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+        const sessionId = req.cookies['sid'];
+        this.sandboxService.releaseUserSession(sessionId);
+        res.clearCookie('sid');
+    }
+
     // 개발용 API입니다. 배포 시 노출되면 안됩니다.
     @Delete('clear')
     @HideInProduction()

--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -1,10 +1,14 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable, Logger } from '@nestjs/common';
-import { parseStringToJson, filterContainerInfo, filterImageInfo } from './utils';
+import {
+    parseStringToJson,
+    filterContainerInfo,
+    filterImageInfo,
+    getHashValueFromIP,
+} from './utils';
 import { requestDockerCommand } from './exec.api';
 import { Container, ContainerData, Image, ImageData } from './types/elements';
 import { CacheService } from '../common/cache/cache.service';
-import { randomUUID } from 'crypto';
 import { formatAxiosError } from '../common/exception/axios-formatter';
 import { isAxiosError } from 'axios';
 import { HOST_STATUS } from './constant';
@@ -157,7 +161,7 @@ export class SandboxService {
         );
     }
 
-    async assignContainer() {
+    async assignContainer(ipAddress: string) {
         const containerId = await this.createContainer();
         let containerPort;
 
@@ -173,7 +177,7 @@ export class SandboxService {
             throw startError;
         }
 
-        const newSessionId = randomUUID();
+        const newSessionId = getHashValueFromIP(ipAddress);
         this.cacheService.set(newSessionId, {
             sessionId: newSessionId,
             containerId,

--- a/backend/src/sandbox/utils.ts
+++ b/backend/src/sandbox/utils.ts
@@ -1,4 +1,5 @@
 import { Image, Container, ImageData, ContainerData } from './types/elements';
+import crypto from 'crypto';
 
 export function parseStringToJson(datas: string) {
     return datas.split('\n').reduce<Array<ImageData | ContainerData>>((jsonDatas, line) => {
@@ -27,4 +28,8 @@ export function filterImageInfo(images: Array<ImageData>) {
         });
         return imageReducer;
     }, []);
+}
+
+export function getHashValueFromIP(ipAddress: string) {
+    return crypto.createHash('sha256').update(ipAddress).digest('hex');
 }

--- a/frontend/src/api/quiz.ts
+++ b/frontend/src/api/quiz.ts
@@ -136,3 +136,11 @@ export const requestQuizAccessability = async (quizId: number) => {
     }
     return true;
 };
+
+export const requestReleaseSession = async (navigate: NavigateFunction) => {
+    try {
+        await axios.delete(`/api/sandbox/release`);
+    } catch (error) {
+        return handleErrorResponse(error, navigate);
+    }
+};

--- a/frontend/src/api/timer.ts
+++ b/frontend/src/api/timer.ts
@@ -1,11 +1,9 @@
 import axios from 'axios';
 import { ExpirationTime } from '../types/timer';
 
-export const requestExpriationTime = async (): Promise<ExpirationTime | object> => {
+export const requestExpirationTime = async (): Promise<ExpirationTime | object> => {
     try {
-        const response = await axios.get<ExpirationTime>(
-            `/api/sandbox/endDate`
-        );
+        const response = await axios.get<ExpirationTime>(`/api/sandbox/endDate`);
         return response.data;
     } catch (error) {
         console.error(error);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,9 +3,9 @@ import dropDownImage from '../assets/dropDown.svg';
 import StartButton from './StartButton';
 import { Link } from 'react-router-dom';
 import { SidebarSectionProps } from '../types/sidebar';
-import { Timer } from './Timer';
 import { requestExpriationTime } from '../api/timer';
 import { ExpirationTime } from '../types/timer';
+import TimerArea from './TimerArea';
 
 const links = [
     { title: 'Home', path: '/' },
@@ -75,6 +75,7 @@ const Sidebar = () => {
         };
         fetchTime();
     }, []);
+
     return (
         <nav className='fixed h-[calc(100vh-4rem)] w-[17rem] bg-gray-100 mt-16 flex flex-col justify-between'>
             <div className='flex-grow'>
@@ -89,7 +90,11 @@ const Sidebar = () => {
                 <SidebarSection title='Docker Image 학습' links={dockerImageLinks} />
                 <SidebarSection title='Docker Container 학습' links={dockerContainerLinks} />
             </div>
-            {maxAge ? <Timer expirationTime={maxAge} /> : <StartButton setMaxAge={setMaxAge} />}
+            {maxAge ? (
+                <TimerArea expirationTime={maxAge} setMaxAge={setMaxAge} />
+            ) : (
+                <StartButton setMaxAge={setMaxAge} />
+            )}
         </nav>
     );
 };

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import dropDownImage from '../assets/dropDown.svg';
 import StartButton from './StartButton';
 import { Link } from 'react-router-dom';
 import { SidebarSectionProps } from '../types/sidebar';
-import { requestExpriationTime } from '../api/timer';
+import { requestExpirationTime } from '../api/timer';
 import { ExpirationTime } from '../types/timer';
 import TimerArea from './TimerArea';
 
@@ -66,7 +66,7 @@ const Sidebar = () => {
     const [maxAge, setMaxAge] = useState<number>(0);
     useEffect(() => {
         const fetchTime = async () => {
-            const data = await requestExpriationTime();
+            const data = await requestExpirationTime();
             if (Object.keys(data).includes('endDate')) {
                 const expirationData = data as ExpirationTime;
                 const maxAge = new Date(expirationData.endDate).getTime();

--- a/frontend/src/components/StartButton.tsx
+++ b/frontend/src/components/StartButton.tsx
@@ -36,7 +36,7 @@ const StartButton = (props: StartButtonProps) => {
                         <span>loading</span>
                     </>
                 ) : (
-                    '시작하기'
+                    '학습 시작하기'
                 )}
             </button>
         </div>

--- a/frontend/src/components/StartButton.tsx
+++ b/frontend/src/components/StartButton.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createHostContainer } from '../api/quiz';
 import { LoaderCircle } from 'lucide-react';
-import { requestExpriationTime } from '../api/timer';
+import { requestExpirationTime } from '../api/timer';
 import { ExpirationTime } from '../types/timer';
 
 type StartButtonProps = {
@@ -17,7 +17,7 @@ const StartButton = (props: StartButtonProps) => {
     const handleButtonClick = async () => {
         setLoading(true);
         const success = await createHostContainer(navigate);
-        const { endDate } = (await requestExpriationTime()) as ExpirationTime;
+        const { endDate } = (await requestExpirationTime()) as ExpirationTime;
         if (success) {
             setLoading(false);
             setMaxAge(new Date(endDate).getTime());

--- a/frontend/src/components/StartButton.tsx
+++ b/frontend/src/components/StartButton.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createHostContainer } from '../api/quiz';
 import { LoaderCircle } from 'lucide-react';
-import { MAX_TIME } from '../constant/timer';
+import { requestExpriationTime } from '../api/timer';
+import { ExpirationTime } from '../types/timer';
 
 type StartButtonProps = {
     setMaxAge: React.Dispatch<React.SetStateAction<number>>;
@@ -16,10 +17,10 @@ const StartButton = (props: StartButtonProps) => {
     const handleButtonClick = async () => {
         setLoading(true);
         const success = await createHostContainer(navigate);
-
+        const { endDate } = (await requestExpriationTime()) as ExpirationTime;
         if (success) {
             setLoading(false);
-            setMaxAge(new Date().getTime() + MAX_TIME);
+            setMaxAge(new Date(endDate).getTime());
         }
     };
 

--- a/frontend/src/components/StopButton.tsx
+++ b/frontend/src/components/StopButton.tsx
@@ -1,0 +1,30 @@
+import { requestReleaseSession } from '../api/quiz';
+import { useNavigate } from 'react-router-dom';
+
+type StopButtonProps = {
+    setMaxAge: React.Dispatch<React.SetStateAction<number>>;
+};
+
+const StopButton = ({ setMaxAge }: StopButtonProps) => {
+    const navigate = useNavigate();
+
+    const handleStopButtonClick = async () => {
+        await requestReleaseSession(navigate);
+        setMaxAge(0);
+        navigate('/');
+    };
+
+    return (
+        <>
+            <button
+                type='button'
+                onClick={handleStopButtonClick}
+                className='w-full rounded-xl text-white bg-red-500 text-xl flex items-center justify-center'
+            >
+                학습 종료
+            </button>
+        </>
+    );
+};
+
+export default StopButton;

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { HOUR, MINUTE, SECOND, MAX_TIME } from '../constant/timer';
+import { HOUR, MINUTE, SECOND } from '../constant/timer';
 
 const parseTime = (time: number) => {
     const hour = Math.floor(time / HOUR);
@@ -16,7 +16,7 @@ type TimerProps = {
 };
 
 export const Timer = (props: TimerProps) => {
-    const expriationTime = props.expirationTime || new Date().getTime() + MAX_TIME;
+    const expriationTime = props.expirationTime;
     const [leftTime, setLeftTime] = useState(expriationTime - new Date().getTime());
     useEffect(() => {
         const timer = setInterval(() => setLeftTime(leftTime - SECOND), SECOND);
@@ -29,7 +29,7 @@ export const Timer = (props: TimerProps) => {
 
     return (
         <>
-            <span className='flex justify-center align-middle font-bold text-Moby-Blue text-3xl content-center mb-5'>
+            <span className='flex justify-center align-middle font-bold text-Moby-Blue text-3xl content-center mb-2'>
                 {parseTime(leftTime)}
             </span>
         </>

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -16,8 +16,8 @@ type TimerProps = {
 };
 
 export const Timer = (props: TimerProps) => {
-    const expriationTime = props.expirationTime;
-    const [leftTime, setLeftTime] = useState(expriationTime - new Date().getTime());
+    const expirationTime = props.expirationTime;
+    const [leftTime, setLeftTime] = useState(expirationTime - new Date().getTime());
     useEffect(() => {
         const timer = setInterval(() => setLeftTime(leftTime - SECOND), SECOND);
         if (leftTime < 0) clearInterval(timer);

--- a/frontend/src/components/TimerArea.tsx
+++ b/frontend/src/components/TimerArea.tsx
@@ -1,0 +1,21 @@
+import { Timer } from './Timer';
+import StopButton from './StopButton';
+
+type TimerAreaProps = {
+    expirationTime: number;
+    setMaxAge: React.Dispatch<React.SetStateAction<number>>;
+};
+
+const TimerArea = ({ expirationTime, setMaxAge }: TimerAreaProps) => {
+    return (
+        <div className='p-2'>
+            <span className='w-full text-gray-400 text-sm flex justify-center align-middle'>
+                남은 학습시간
+            </span>
+            <Timer expirationTime={expirationTime} />
+            <StopButton setMaxAge={setMaxAge} />
+        </div>
+    );
+};
+
+export default TimerArea;


### PR DESCRIPTION
## 작업 개요

- Resolves #255 
- Resolves #254 
- Resolves #248 


## 작업 상세 내용

- 세션 해제 요청에 대한 API만들기(BE)
- 학습 종료 버튼 만들기 및 세션 해제 요청 보내기(FE)
- 한 IP당 컨테이너 하나만 생성되도록 제한(BE)
- 타이머의 경우 `IP`가 동일한 기기로 요청했을 때 타이머 동기화 시키기

### 한 IP당 컨테이너 하나만 생성되도록 제한
- `Sandbox.service.ts`의 assignContainer함수 내부에서 `IP`를 활용해 해시화 한 후 `SessionID`를 저장하도록 하였음.
- `Sandbox.controller.ts`의 `start` controller에서 현재 `start`요청을 보낸 `IP`주소에 대해서 해시값을 생성한 후 세션 테이블에 이미 할당되었는지 확인한다. 확인 후 이미 할당되었다면, Cookie값으로 다시 설정해준다.

### 타이머의 경우 `IP`가 동일한 기기로 요청했을 때 타이머 동기화 시키기

학습 시작버튼을 누르면 기존에는 `현재시간 + 4시간`으로 하여 타이머 초기 시간을 설정하였다. 이렇게 하다보니 같은 IP의 사용자가 다수의 웹브라우저를 띄우고 학습 시작버튼을 누르면 시간이 죄다 다른 문제가 발생했다.

해당 문제를 해결하기 위해서 `학습 시작` 요청을 보내고 응답을 잘 받으면 `시간 정보 요청`을 보내고 해당 시간 데이터로 타이머를 초기화하도록 수정하였다.

## 참고자료(선택)

## 문제점 혹은 고민(선택)
- 남은 태스크 중 호스트 컨테이너 시간에 따라 자동 종료 로직 작성이라는게 서버와 클라이언트의 마지막 상호작용 기준 일정 시간이 지나면 삭제하는건가요?
- 탭을 닫으면 컨테이너, 이미지 삭제 로직작성 태스크의 경우 만약  동일 사용자가 웹 브라우저를 여러개 띄워놓고 탭을 하나라도 닫으면 삭제하는게 맞나요??