### PR TITLE
퀴즈 페이지 리팩토링, 터미널 리사이징 이벤트 등록

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,10 +47,7 @@ const App = () => {
                             path='/what-is-container-lifecycle'
                             element={<DockerContainerLifeCyclePage />}
                         />
-                        <Route
-                            path='/quiz/:quizNumber'
-                            element={<QuizPage showAlert={showAlert} />}
-                        />
+                        <Route path='/quiz/:quizId' element={<QuizPage showAlert={showAlert} />} />
                         <Route path='/error/:id' element={<ErrorPage />} />
                     </Routes>
                 </div>

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -5,18 +5,18 @@ import { QuizSubmitResultModal } from '../modals/QuizSubmitResultModal';
 import { SubmitStatus } from '../../types/quiz';
 
 type QuizButtonsProps = {
-    quizId: number;
+    quizNumber: number;
     answer: string;
     showAlert: (message: string) => void;
 };
 
-const QuizButtons = ({ quizId, answer, showAlert }: QuizButtonsProps) => {
+const QuizButtons = ({ quizNumber, answer, showAlert }: QuizButtonsProps) => {
     const [submitResult, setSubmitResult] = useState<SubmitStatus>('FAIL');
     const [openModal, setOpenModal] = useState(false);
     const navigate = useNavigate();
 
     const handleSubmitButtonClick = async () => {
-        const submitResponse = await requestSubmitResult(quizId, answer, navigate);
+        const submitResponse = await requestSubmitResult(quizNumber, answer, navigate);
         if (submitResponse == null) {
             return;
         }
@@ -26,37 +26,36 @@ const QuizButtons = ({ quizId, answer, showAlert }: QuizButtonsProps) => {
     };
 
     const handlePrevButtonClick = async () => {
-        if (quizId === 1) {
+        if (quizNumber === 1) {
             showAlert('처음 문제입니다');
             return;
         }
 
-        if (quizId === 4) {
+        if (quizNumber === 4) {
             navigate('/what-is-container-lifecycle');
             return;
         }
 
-        navigate(`/quiz/${quizId - 1}`);
+        navigate(`/quiz/${quizNumber - 1}`);
     };
 
     const handleNextButtonClick = async () => {
-        if (quizId > 8) {
+        if (quizNumber > 8) {
             showAlert('마지막 문제입니다.');
             return;
         }
 
-        if (quizId === 3) {
+        if (quizNumber === 3) {
             navigate('/what-is-docker-container');
             return;
         }
 
-        const isAccessable = await requestQuizAccessability(quizId + 1);
+        const isAccessable = await requestQuizAccessability(quizNumber + 1);
         if (!isAccessable) {
             showAlert('아직 이동할 수 없습니다.');
             return;
         }
-
-        navigate(`/quiz/${quizId + 1}`);
+        navigate(`/quiz/${quizNumber + 1}`);
     };
 
     return (

--- a/frontend/src/components/quiz/QuizInputBox.tsx
+++ b/frontend/src/components/quiz/QuizInputBox.tsx
@@ -10,7 +10,7 @@ const QuizInputBox = ({ answer, setAnswer }: QuizInputBoxProps) => {
     return (
         <div className='w-[85%] flex justify-end'>
             <input
-                className='flex justify-center w-60 h-8 rounded-lg border border-gray-300 mt-4 outline-none ml-1'
+                className='w-60 h-8 rounded-lg border border-gray-300 mt-4 outline-none ml-1'
                 type='text'
                 onChange={handleChange}
                 value={answer}

--- a/frontend/src/components/quiz/QuizInputBox.tsx
+++ b/frontend/src/components/quiz/QuizInputBox.tsx
@@ -9,15 +9,13 @@ const QuizInputBox = ({ answer, setAnswer }: QuizInputBoxProps) => {
     };
     return (
         <div className='w-[85%] flex justify-end'>
-            <div className='flex justify-center w-60 h-8 rounded-lg border border-gray-300 mt-4'>
-                <input
-                    className='w-full outline-none ml-1'
-                    type='text'
-                    onChange={handleChange}
-                    value={answer}
-                    placeholder='정답을 입력해주세요.'
-                />
-            </div>
+            <input
+                className='flex justify-center w-60 h-8 rounded-lg border border-gray-300 mt-4 outline-none ml-1'
+                type='text'
+                onChange={handleChange}
+                value={answer}
+                placeholder='정답을 입력해주세요.'
+            />
         </div>
     );
 };

--- a/frontend/src/components/quiz/QuizNodes.tsx
+++ b/frontend/src/components/quiz/QuizNodes.tsx
@@ -11,11 +11,18 @@ type Props = {
 export const QuizNodes = ({ showAlert, quizId }: Props) => {
     const { title, content } = useQuizData(quizId);
 
-    const isCustomQuiz = CUSTOM_QUIZZES.includes(+quizId);
+    const quizNumber = +quizId;
+    const isCustomQuiz = CUSTOM_QUIZZES.includes(quizNumber);
 
     return {
         head: <h1 className='font-bold text-3xl text-Dark-Blue mb-3'>{title}</h1>,
         description: <QuizDescription content={content} />,
-        submit: <QuizSubmitArea quizId={+quizId} showInput={isCustomQuiz} showAlert={showAlert} />,
+        submit: (
+            <QuizSubmitArea
+                quizNumber={quizNumber}
+                showInput={isCustomQuiz}
+                showAlert={showAlert}
+            />
+        ),
     };
 };

--- a/frontend/src/components/quiz/QuizNodes.tsx
+++ b/frontend/src/components/quiz/QuizNodes.tsx
@@ -1,0 +1,21 @@
+import { useQuizData } from '../../hooks/useQuizData';
+import { CUSTOM_QUIZZES } from '../../constant/quiz';
+import QuizDescription from './QuizDescription';
+import { QuizSubmitArea } from './QuizSubmitArea';
+
+type Props = {
+    showAlert: (message: string) => void;
+    quizId: string;
+};
+
+export const QuizNodes = ({ showAlert, quizId }: Props) => {
+    const { title, content } = useQuizData(quizId);
+
+    const isCustomQuiz = CUSTOM_QUIZZES.includes(+quizId);
+
+    return {
+        head: <h1 className='font-bold text-3xl text-Dark-Blue mb-3'>{title}</h1>,
+        description: <QuizDescription content={content} />,
+        submit: <QuizSubmitArea quizId={+quizId} showInput={isCustomQuiz} showAlert={showAlert} />,
+    };
+};

--- a/frontend/src/components/quiz/QuizPage.tsx
+++ b/frontend/src/components/quiz/QuizPage.tsx
@@ -1,82 +1,37 @@
-import { useEffect, useState, useRef } from 'react';
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
-import DockerVisualization from '../visualization/DockerVisualization';
-import QuizDescription from '../quiz/QuizDescription';
-import XTerminal from '../quiz/XTerminal';
-import useDockerVisualization from '../../hooks/useDockerVisualization';
-import { QuizSubmitArea } from './QuizSubmitArea';
-import { CUSTOM_QUIZZES } from '../../constant/quiz';
-import { useQuizData } from '../../hooks/useQuizData';
-import { HostStatus, HOST_STATUS } from '../../constant/hostStatus';
-import { requestHostStatus } from '../../api/quiz';
+import { QuizNodes } from './QuizNodes';
+import { VisualizationNodes } from './VisualizationNodes';
+import { QuizPageWrapper } from './QuizPageWrapper';
 
-type Props = {
+type QuizContentProps = {
+    showAlert: (message: string) => void;
+    quizId: string;
+};
+
+type QuizPageProps = {
     showAlert: (message: string) => void;
 };
 
-export const QuizPage = ({ showAlert }: Props) => {
-    const navigate = useNavigate();
-    const params = useParams<{ quizNumber: string }>();
-    const quizNumber = params.quizNumber ?? '';
-    const { title, content } = useQuizData(quizNumber);
-    const [hostStatus, setHostStatus] = useState<HostStatus>(HOST_STATUS.STARTING);
-    const pollingRef = useRef<boolean>(true);
-    const pollingIntervalRef = useRef<number | null>(null);
-    const visualizationProps = useDockerVisualization();
-
-    const checkHostStatus = async () => {
-        const response = await requestHostStatus(navigate);
-
-        if (!response) {
-            return;
-        }
-
-        setHostStatus(response);
-
-        if (response === HOST_STATUS.READY) {
-            pollingRef.current = false;
-            if (pollingIntervalRef.current) {
-                clearInterval(pollingIntervalRef.current);
-            }
-        }
-    };
-
-    useEffect(() => {
-        const pollingHostStatus = async () => {
-            await checkHostStatus();
-
-            if (pollingRef.current) {
-                pollingIntervalRef.current = setInterval(checkHostStatus, 1000);
-            } else {
-                visualizationProps.setInitVisualization();
-            }
-        };
-
-        pollingHostStatus();
-
-        return () => {
-            if (pollingIntervalRef.current) {
-                clearInterval(pollingIntervalRef.current);
-                pollingIntervalRef.current = null;
-            }
-        };
-    }, [navigate]);
-
-    const isCustomQuiz = CUSTOM_QUIZZES.includes(+quizNumber);
+export const QuizContent = ({ showAlert, quizId }: QuizContentProps) => {
+    const quizNodes = QuizNodes({ showAlert, quizId });
+    const visualNodes = VisualizationNodes();
 
     return (
         <div className='w-[calc(100vw-17rem)]'>
-            <h1 className='font-bold text-3xl text-Dark-Blue mb-3'>{title}</h1>
+            {quizNodes.head}
             <section className='flex h-1/2'>
-                <QuizDescription content={content} />
-                <DockerVisualization {...visualizationProps} />
+                {quizNodes.description}
+                {visualNodes.visualization}
             </section>
-            <XTerminal
-                updateVisualizationData={visualizationProps.updateVisualizationData}
-                hostStatus={hostStatus}
-            />
-            <QuizSubmitArea quizId={+quizNumber} showInput={isCustomQuiz} showAlert={showAlert} />
+            {visualNodes.terminal}
+            {quizNodes.submit}
         </div>
+    );
+};
+
+export const QuizPage = ({ showAlert }: QuizPageProps) => {
+    return (
+        <QuizPageWrapper showAlert={showAlert}>
+            {(quizId) => <QuizContent showAlert={showAlert} quizId={quizId} />}
+        </QuizPageWrapper>
     );
 };

--- a/frontend/src/components/quiz/QuizPageWrapper.tsx
+++ b/frontend/src/components/quiz/QuizPageWrapper.tsx
@@ -1,0 +1,42 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { requestQuizAccessability } from '../../api/quiz';
+
+type QuizPageWrapperProps = {
+    children: (quizId: string) => React.ReactNode;
+    showAlert: (message: string) => void;
+};
+
+export const QuizPageWrapper = ({ children, showAlert }: QuizPageWrapperProps) => {
+    const { quizId } = useParams<{ quizId: string }>();
+    const [isValidated, setIsValidated] = useState(false);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const validateQuiz = async () => {
+            const quizNumber = Number(quizId);
+
+            if (Number.isNaN(quizNumber) || quizNumber < 1 || quizNumber > 9) {
+                navigate('/error/404');
+                return;
+            }
+
+            const isAccessable = await requestQuizAccessability(quizNumber);
+            if (!isAccessable) {
+                showAlert('이전 퀴즈를 먼저 완료해주세요.');
+                navigate('/');
+                return;
+            }
+
+            setIsValidated(true);
+        };
+
+        validateQuiz();
+    }, [quizId, navigate, showAlert]);
+
+    if (!isValidated) {
+        return null;
+    }
+
+    return <>{children(quizId as string)}</>;
+};

--- a/frontend/src/components/quiz/QuizSubmitArea.tsx
+++ b/frontend/src/components/quiz/QuizSubmitArea.tsx
@@ -3,18 +3,18 @@ import QuizButtons from './QuizButtons';
 import QuizInputBox from './QuizInputBox';
 
 type QuizSubmitAreaProps = {
-    quizId: number;
+    quizNumber: number;
     showInput: boolean;
     showAlert: (message: string) => void;
 };
 
-export const QuizSubmitArea = ({ quizId, showInput, showAlert }: QuizSubmitAreaProps) => {
+export const QuizSubmitArea = ({ quizNumber, showInput, showAlert }: QuizSubmitAreaProps) => {
     const [answer, setAnswer] = useState('');
 
     return (
         <>
             {showInput && <QuizInputBox answer={answer} setAnswer={setAnswer} />}
-            <QuizButtons quizId={quizId} answer={answer} showAlert={showAlert} />
+            <QuizButtons quizNumber={quizNumber} answer={answer} showAlert={showAlert} />
         </>
     );
 };

--- a/frontend/src/components/quiz/VisualizationNodes.tsx
+++ b/frontend/src/components/quiz/VisualizationNodes.tsx
@@ -1,0 +1,63 @@
+import DockerVisualization from '../visualization/DockerVisualization';
+import XTerminal from './XTerminal';
+import { useEffect, useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useDockerVisualization from '../../hooks/useDockerVisualization';
+import { HostStatus, HOST_STATUS } from '../../constant/hostStatus';
+import { requestHostStatus } from '../../api/quiz';
+
+export const VisualizationNodes = () => {
+    const navigate = useNavigate();
+    const [hostStatus, setHostStatus] = useState<HostStatus>(HOST_STATUS.STARTING);
+    const pollingRef = useRef<boolean>(true);
+    const pollingIntervalRef = useRef<number | null>(null);
+    const visualizationProps = useDockerVisualization();
+
+    const checkHostStatus = async () => {
+        const response = await requestHostStatus(navigate);
+
+        if (!response) {
+            return;
+        }
+
+        setHostStatus(response);
+
+        if (response === HOST_STATUS.READY) {
+            pollingRef.current = false;
+            if (pollingIntervalRef.current) {
+                clearInterval(pollingIntervalRef.current);
+            }
+        }
+    };
+
+    useEffect(() => {
+        const pollingHostStatus = async () => {
+            await checkHostStatus();
+
+            if (pollingRef.current) {
+                pollingIntervalRef.current = setInterval(checkHostStatus, 1000);
+            } else {
+                visualizationProps.setInitVisualization();
+            }
+        };
+
+        pollingHostStatus();
+
+        return () => {
+            if (pollingIntervalRef.current) {
+                clearInterval(pollingIntervalRef.current);
+                pollingIntervalRef.current = null;
+            }
+        };
+    }, [navigate]);
+
+    return {
+        visualization: <DockerVisualization {...visualizationProps} />,
+        terminal: (
+            <XTerminal
+                updateVisualizationData={visualizationProps.updateVisualizationData}
+                hostStatus={hostStatus}
+            />
+        ),
+    };
+};

--- a/frontend/src/components/quiz/VisualizationNodes.tsx
+++ b/frontend/src/components/quiz/VisualizationNodes.tsx
@@ -1,55 +1,13 @@
 import DockerVisualization from '../visualization/DockerVisualization';
 import XTerminal from './XTerminal';
-import { useEffect, useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
 import useDockerVisualization from '../../hooks/useDockerVisualization';
-import { HostStatus, HOST_STATUS } from '../../constant/hostStatus';
-import { requestHostStatus } from '../../api/quiz';
+import { useHostStatus } from '../../hooks/useHostStatus';
 
 export const VisualizationNodes = () => {
-    const navigate = useNavigate();
-    const [hostStatus, setHostStatus] = useState<HostStatus>(HOST_STATUS.STARTING);
-    const pollingRef = useRef<boolean>(true);
-    const pollingIntervalRef = useRef<number | null>(null);
     const visualizationProps = useDockerVisualization();
-
-    const checkHostStatus = async () => {
-        const response = await requestHostStatus(navigate);
-
-        if (!response) {
-            return;
-        }
-
-        setHostStatus(response);
-
-        if (response === HOST_STATUS.READY) {
-            pollingRef.current = false;
-            if (pollingIntervalRef.current) {
-                clearInterval(pollingIntervalRef.current);
-            }
-        }
-    };
-
-    useEffect(() => {
-        const pollingHostStatus = async () => {
-            await checkHostStatus();
-
-            if (pollingRef.current) {
-                pollingIntervalRef.current = setInterval(checkHostStatus, 1000);
-            } else {
-                visualizationProps.setInitVisualization();
-            }
-        };
-
-        pollingHostStatus();
-
-        return () => {
-            if (pollingIntervalRef.current) {
-                clearInterval(pollingIntervalRef.current);
-                pollingIntervalRef.current = null;
-            }
-        };
-    }, [navigate]);
+    const hostStatus = useHostStatus({
+        setInitVisualization: visualizationProps.setInitVisualization,
+    });
 
     return {
         visualization: <DockerVisualization {...visualizationProps} />,

--- a/frontend/src/components/quiz/XTerminal.tsx
+++ b/frontend/src/components/quiz/XTerminal.tsx
@@ -54,8 +54,8 @@ const XTerminal = ({ updateVisualizationData, hostStatus }: XTerminalProps) => {
     }, [hostStatus]);
 
     return (
-        <div className='h-[30%] w-[83.5%] border rounded-lg border-gray-300 bg-gray-50 ml-4'>
-            <div ref={terminalRef} className='h-full w-full p-2' />
+        <div className='h-[30%] w-[83.5%] border rounded-lg border-black bg-black ml-4'>
+            <div ref={terminalRef} className='h-full w-full p-2 custom-terminal' />
         </div>
     );
 };

--- a/frontend/src/hooks/useQuizData.ts
+++ b/frontend/src/hooks/useQuizData.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Quiz } from '../types/quiz';
 import { requestQuizData } from '../api/quiz';
 
-export const useQuizData = (quizNumber: string) => {
+export const useQuizData = (quizId: string) => {
     const [quizData, setQuizData] = useState<Quiz>({
         id: 0,
         title: '',
@@ -13,13 +13,13 @@ export const useQuizData = (quizNumber: string) => {
 
     useEffect(() => {
         const fetchQuizData = async () => {
-            const data = await requestQuizData(quizNumber, navigate);
+            const data = await requestQuizData(quizId, navigate);
             if (!data) return;
 
             setQuizData(data);
         };
         fetchQuizData();
-    }, [quizNumber, navigate]);
+    }, [quizId, navigate]);
 
     return {
         id: quizData.id,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+    .custom-terminal {
+        scrollbar-width: thin;
+        scrollbar-color: #666 #1e1e1e;
+    }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,9 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer components {
-    .custom-terminal {
-        scrollbar-width: thin;
-        scrollbar-color: #666 #1e1e1e;
-    }
+.custom-terminal {
+    scrollbar-width: thin;
+    scrollbar-color: #666 #1e1e1e;
 }

--- a/frontend/src/utils/terminalUtils.ts
+++ b/frontend/src/utils/terminalUtils.ts
@@ -7,12 +7,26 @@ export function createTerminal(container: HTMLElement): Terminal {
     const terminal = new Terminal({
         cursorBlink: true,
         fontSize: 14,
+        rows: 20,
     });
 
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.open(container);
     fitAddon.fit();
+
+    const handleResize = () => {
+        fitAddon.fit();
+        terminal.resize(terminal.cols, 20);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    const originalDispose = terminal.dispose.bind(terminal);
+    terminal.dispose = () => {
+        window.removeEventListener('resize', handleResize);
+        originalDispose();
+    };
 
     return terminal;
 }
@@ -50,7 +64,7 @@ export const handleEnter = async (
     const commandResponse = await requestCommandResult(command, navigate, term, handleCommandError);
     term.write('\r\n' + commandResponse);
     await updateVisualization(command);
-    
+
     term.write('\r\n~$ ');
 };
 


### PR DESCRIPTION
## 작업 개요
- #256 
- resolve #258 
- resolve #259 
- resolve #262 

- [관련 wiki](https://github.com/boostcampwm-2024/web34-LearnDocker/wiki/%5B5%EC%A3%BC-2%EC%9D%BC%EC%B0%A8---J278-%ED%99%8D%EA%B7%9C%EC%84%A0%5D-%EA%B0%9C%EB%B0%9C-%EC%9D%BC%EC%A7%80%28%ED%80%B4%EC%A6%88-%ED%8E%98%EC%9D%B4%EC%A7%80-%EB%A6%AC%ED%8C%A9%ED%86%A0%EB%A7%81%29)
## 작업 상세 내용
### 퀴즈 페이지 리팩토링
- 상태에 따른 컴포넌트 분리를 했습니다.
  - 아직 리랜더링 관련 문제는 해결 못 했습니다.
- 컴포넌트 내부에서 QuizId, QuizNumber 용어 통일을 했습니다.
- quizPage 랜더링 전 파라미터로 들어온 퀴즈 Id, 접근 권한 확인하는 QuizPageWrapper를 구현했습니다.
### 터미널 관련 
- 윈도우 창의 크기를 줄인 다음 새로고침하면 터미널이 줄어든 상태로 유지되었습니다.
- 사용자 ux 측면에서 안 좋다고 생각이 들어서 resize 이벤트를 등록했습니다.
## 문제점 혹은 고민(선택)
### 다음 버튼 누르면 퀴즈 제목과 퀴즈 내용만 리랜더링 되도록 시도 했습니다.
  - 일단 상태에 따른 컴포넌트 분리는 했지만
  - 버튼이 navigate(’/quiz/${quiz - 1}’)로 되어 있습니다
      - 페이지가 이동 되기 때문에 페이지 전체가 랜더링 됩니다.
  - 또한 컴포넌트 마다 useNavigate를 사용하는데 이것도 리랜더링 이슈가 있는 것 같습니다.
  - 생각보다 고칠게 많아서 이 상태에 만족을 하고 다른 태스크를 할 지 더 시도 할 지 고민중입니다.
### 학습 시작 버튼을 누르지 않은 상태와 퀴즈 접근 권한이 없을때 둘 다 403
- 학습 시작 버튼을 누르지 않고 퀴즈 페이지 접근
![image](https://github.com/user-attachments/assets/67efa3c8-be81-4364-be95-a1fa2ef0f396)
- 학습 시작 버튼을 눌렀지만 레벨이 부족한 경우
![image](https://github.com/user-attachments/assets/defeb69e-a538-4421-a50e-076a48474270)

- 지금은 구분이 안 되어서 두 개를 구분을 하면 좋을 것 같습니다

