### PR TITLE
레지스트리 세팅, 퀴즈 이미지 준비, 볼륨 마운트 못하게 막기

### DIFF
--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -26,15 +26,15 @@ export class QuizService {
 
         const quizzeData = [
             {
-                //TODO: pull 명령어나 이미지 명령어의 경우 앞에 registry를 붙여야 된다고 알려주기
                 id: 1,
                 title: 'Docker Image 가져오기',
                 content:
                     'Docker의 첫 걸음을 시작해볼까요?\n' +
-                    'Docker Hub에서 제공하는 hello-world 이미지를 가져와보세요.\n\n' +
+                    'learndocker.io에서 제공하는 hello-world 이미지를 가져와보세요.\n\n' +
                     '1. docker pull 명령어를 사용하여 hello-world 이미지를 다운로드하세요.\n' +
                     '2. 이미지가 성공적으로 다운로드되면 자동으로 로컬 시스템에 저장됩니다.\n\n' +
-                    '힌트: docker pull <이미지명> 형식으로 명령어를 작성하세요.',
+                    '힌트: docker pull <이미지명> 형식으로 명령어를 작성하세요.\n' + 
+                    '힌트: 특정 레지스트리에서 이미지를 가져올 때는 이미지명 앞에 <레지스트리 주소/>를 붙여주세요.',
             },
             {
                 id: 2,
@@ -42,7 +42,7 @@ export class QuizService {
                 content:
                     '로컬 시스템에 저장된 Docker 이미지들을 확인해볼까요?\n\n' +
                     '1. docker images 명령어를 사용하여 현재 시스템에 있는 모든 Docker 이미지를 조회하세요.\n' +
-                    '2. 명령어 실행 후 출력된 결과에서 hello-world 이미지의 Image ID 최소 앞 4자리를 입력하세요.\n\n' +
+                    '2. 명령어 실행 후 출력된 결과에서 learndocker.io/hello-world 이미지 ID를 앞 4자리 이상 입력하세요.\n\n' +
                     '힌트: 이미지 목록을 확인하는 명령어는 별도의 인자가 필요하지 않습니다.',
             },
             {
@@ -62,7 +62,6 @@ export class QuizService {
                     '1. docker create 명령어를 사용하여 hello-world 이미지로부터 컨테이너를 생성하세요.\n\n' +
                     '힌트: docker create <이미지명> 형식으로 명령어를 작성하세요.',
             },
-            //TODO: hello-world, hello-world2(가제) 이미지를 커스텀 해서 터미널에 정답이 나오게 하기
             {
                 id: 5,
                 title: 'Container 실행하기',
@@ -70,20 +69,20 @@ export class QuizService {
                     '생성된 컨테이너를 실행해보겠습니다.\n\n' +
                     '1. docker start 명령어를 사용하여 이전 단계에서 생성한 컨테이너를 실행하세요.\n' +
                     '2. 컨테이너 ID나 이름을 사용하여 실행할 수 있습니다.\n' +
-                    '3. 실행 후 터미널에 표시되는 "answer: " 다음에 나오는 값을 입력해주세요.\n\n' +
-                    '힌트: docker start <컨테이너ID> 형식으로 명령어를 작성하세요.\n' +
+                    '3. 실행 후 터미널에 표시되는 "Answer: " 다음에 나오는 값을 입력해주세요.\n\n' +
+                    '힌트: docker start -a <컨테이너ID> 형식으로 명령어를 작성하세요.\n' +
                     '힌트: 컨테이너ID 전부 적을 필요는 없습니다.',
             },
-            // TODO: hello-world2는 가제 수정 필요
             {
                 id: 6,
                 title: 'Container 생성 및 실행하기',
                 content:
                     '컨테이너의 생성과 실행을 한 번에 수행해봅시다.\n\n' +
-                    '1. docker run 명령어를 사용하여 hello-world2 이미지로 컨테이너를 생성하고 실행하세요.\n' +
+                    '1. docker run 명령어를 사용하여 joke 이미지로 컨테이너를 생성하고 실행하세요.\n' +
                     '2. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n' +
-                    '3. 실행 후 터미널에 표시되는 "answer: " 다음에 나오는 값을 입력해주세요.\n\n' +
-                    '힌트: docker run <이미지명> 형식으로 명령어를 작성하세요.',
+                    '3. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n\n' +
+                    '힌트: docker run <이미지명> 형식으로 명령어를 작성하세요.\n' +
+                    '힌트: 이미지는 learndocker.io/joke를 사용하세요.',
             },
             {
                 id: 7,
@@ -91,7 +90,7 @@ export class QuizService {
                 content:
                     '실행 중이거나 중지된 모든 컨테이너를 확인해봅시다.\n\n' +
                     '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n' +
-                    '2. 출력된 결과에서 hello-world2 컨테이너의 ID 최소 앞 4자리를 입력하세요.\n\n' +
+                    '2. joke 이미지로 만든 컨테이너의 ID 최소 앞 4자리를 입력하세요.\n\n' +
                     '힌트: docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.',
             },
             {

--- a/backend/src/sandbox/pipes/command.pipe.ts
+++ b/backend/src/sandbox/pipes/command.pipe.ts
@@ -1,13 +1,18 @@
 import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
 
 const VALID_REGEX = /^docker\s(?:(?!.*\b(?:sh|bash|exec)\b|.*[;&|<>$`]))/;
+const VOLUME_MOUNT_CHECK_REGEX =
+    /^docker\s+(?:(?:container\s+)?(?:create|run))\s+.*(?:-v\b|--volume\b)/;
 
 @Injectable()
 export class CommandValidationPipe implements PipeTransform {
     transform(value: string) {
         value = value.trim();
-        const validation = value.match(VALID_REGEX);
-        if (!validation) throw new BadRequestException('해당 명령어는 사용이 불가능합니다!');
+        const baseValidation = value.match(VALID_REGEX);
+        const volumeMountCheck = VOLUME_MOUNT_CHECK_REGEX.test(value);
+        const isValid = baseValidation && !volumeMountCheck;
+
+        if (!isValid) throw new BadRequestException('해당 명령어는 사용이 불가능합니다!');
         return value;
     }
 }

--- a/backend/src/sandbox/pipes/command.pipe.ts
+++ b/backend/src/sandbox/pipes/command.pipe.ts
@@ -3,6 +3,7 @@ import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
 const VALID_REGEX = /^docker\s(?:(?!.*\b(?:sh|bash|exec)\b|.*[;&|<>$`]))/;
 const VOLUME_MOUNT_CHECK_REGEX =
     /^docker\s+(?:(?:container\s+)?(?:create|run))\s+.*(?:-v\b|--volume\b)/;
+const PUSH_CHECK_REGEX = /^docker\s+(?:(?:image\s+)?(?:push))/;
 
 @Injectable()
 export class CommandValidationPipe implements PipeTransform {
@@ -10,7 +11,8 @@ export class CommandValidationPipe implements PipeTransform {
         value = value.trim();
         const baseValidation = value.match(VALID_REGEX);
         const volumeMountCheck = VOLUME_MOUNT_CHECK_REGEX.test(value);
-        const isValid = baseValidation && !volumeMountCheck;
+        const pushCheck = PUSH_CHECK_REGEX.test(value);
+        const isValid = baseValidation && !volumeMountCheck && !pushCheck;
 
         if (!isValid) throw new BadRequestException('해당 명령어는 사용이 불가능합니다!');
         return value;

--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -126,7 +126,7 @@ export class SandboxService {
 
     async createContainer() {
         const requestBody = {
-            Image: 'docker:dind',
+            Image: 'dind',
             HostConfig: {
                 Privileged: true,
                 PortBindings: {
@@ -137,6 +137,7 @@ export class SandboxService {
                         },
                     ],
                 },
+                ExtraHosts: ['learndocker.io:172.17.0.1']
             },
             Env: ['DOCKER_TLS_CERTDIR='],
         };

--- a/sandbox/host-container/Dockerfile
+++ b/sandbox/host-container/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker:dind
+
+# learndocker.io가 가리킬 host IP 주소 (172.19.0.1)에 HTTP 요청을 허용하기 위해 필요함
+RUN mkdir -p /etc/docker
+RUN echo '{ "insecure-registries":["learndocker.io"] }' > /etc/docker/daemon.json

--- a/sandbox/host-container/docker-compose.yml
+++ b/sandbox/host-container/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  dind:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: dind
+    privileged: true
+    ports:
+      - "0:2375"
+    environment:
+      - DOCKER_TLS_CERTDIR=
+    extra_hosts:
+      - "learndocker.io:172.17.0.1"
+    network_mode: "bridge"

--- a/sandbox/quiz-images/hello-world/Dockerfile
+++ b/sandbox/quiz-images/hello-world/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest AS builder
+WORKDIR /app
+COPY hello.c .
+RUN apk add --no-cache gcc musl-dev \
+    && gcc -static -Os -fno-ident -fdata-sections -ffunction-sections \
+    -fno-asynchronous-unwind-tables -fno-unwind-tables \
+    -Wl,--gc-sections -Wl,--strip-all \ 
+    -o hello hello.c
+
+FROM scratch
+COPY --from=builder /app/hello /hello
+ENTRYPOINT [ "/hello" ]

--- a/sandbox/quiz-images/hello-world/hello.c
+++ b/sandbox/quiz-images/hello-world/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main() {
+    char answer[45] = "부스트캠프 웹모바일 9기 화이팅!";
+    printf("Answer: %s\n", answer);
+    return 0;
+}

--- a/sandbox/quiz-images/joke/Dockerfile
+++ b/sandbox/quiz-images/joke/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest AS builder
+WORKDIR /app
+COPY joke.c .
+RUN apk add --no-cache gcc musl-dev \
+    && gcc -static -Os -fno-ident -fdata-sections -ffunction-sections \
+    -fno-asynchronous-unwind-tables -fno-unwind-tables \
+    -Wl,--gc-sections -Wl,--strip-all \ 
+    -o joke joke.c
+
+FROM scratch
+COPY --from=builder /app/joke /joke
+ENTRYPOINT [ "/joke" ]

--- a/sandbox/quiz-images/joke/joke.c
+++ b/sandbox/quiz-images/joke/joke.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main() {
+    printf("넌센스 퀴즈입니다!\n");
+    printf("우주인이 술 마시는 장소는?\n");
+    return 0;
+}

--- a/sandbox/registry/docker-compose.yml
+++ b/sandbox/registry/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  registry:
+    image: registry:2
+    ports:
+      - "80:80"
+    environment:
+      REGISTRY_HTTP_ADDR: 0.0.0.0:80
+    restart: always
+    network_mode: "bridge"

--- a/sandbox/setup.ps1
+++ b/sandbox/setup.ps1
@@ -1,0 +1,5 @@
+# .\setup.ps1 으로 실행하세요
+
+Set-Location $PSScriptRoot
+docker build --tag dind:latest --file ./host-container/Dockerfile ./host-container
+docker compose -f registry/docker-compose.yml up -d

--- a/sandbox/setup.ps1
+++ b/sandbox/setup.ps1
@@ -1,5 +1,20 @@
 # .\setup.ps1 으로 실행하세요
 
+# Set working directory to script location
 Set-Location $PSScriptRoot
-docker build --tag dind:latest --file ./host-container/Dockerfile ./host-container
-docker compose -f registry/docker-compose.yml up -d
+
+# Build DinD image
+docker build -t dind:latest -f ./host-container/Dockerfile ./host-container
+
+# Build quiz images
+docker build -t localhost/hello-world -f ./quiz-images/hello-world/Dockerfile ./quiz-images/hello-world
+docker build -t localhost/joke -f ./quiz-images/joke/Dockerfile ./quiz-images/joke
+
+# Start Registry container
+docker compose -f ./registry/docker-compose.yml up -d
+
+Start-Sleep -Seconds 5
+
+# Push images to Registry
+docker push localhost/hello-world
+docker push localhost/joke

--- a/sandbox/setup.sh
+++ b/sandbox/setup.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 
+set -e
+
 cd "$(dirname "$0")"
 
 # DinD 이미지 빌드
 docker build --tag dind:latest --file ./host-container/Dockerfile ./host-container
 
+# hello-world 이미지 빌드
+docker build --tag localhost/hello-world --file ./quiz-images/hello-world/Dockerfile ./quiz-images/hello-world
+
+# joke 이미지 빌드
+docker build --tag localhost/joke --file ./quiz-images/joke/Dockerfile ./quiz-images/joke
+
 # Registry 컨테이너 실행
 docker compose -f ./registry/docker-compose.yml up -d
+
+sleep 5
+
+# Registry에 퀴즈용 이미지 push
+docker push localhost/hello-world
+docker push localhost/joke

--- a/sandbox/setup.sh
+++ b/sandbox/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+# DinD 이미지 빌드
+docker build --tag dind:latest --file ./host-container/Dockerfile ./host-container
+
+# Registry 컨테이너 실행
+docker compose -f ./registry/docker-compose.yml up -d


### PR DESCRIPTION
## 작업 개요

closes #263
closes #264 
closes #267

## 작업 상세 내용

### 레지스트리 세팅
**백엔드 서버 실행하기 전에 sandbox 서버에서 setup 스크립트 실행해야 합니다!**

- dind 이미지를 만들었습니다.
  - daemon.json에 insecure-registries 항목을 추가했습니다.
  - learndocker.io로 pull 요청 보내야 되는데, insecure-registries에 없으면 https 요청 시도합니다.
- 로컬 레지스트리 compose 파일을 만들었습니다.
  - docker compose up -d 하면 레지스트리 뿅 하고 생깁니다.
  - 호스트 환경에 80번 포트로 서버가 열립니다.
- sandbox/setup 스크립트
  - dind 이미지 빌드하고, quiz 이미지 빌드하고, 레지스트리 띄우고, 레지스트리에 push하는 스크립트입니다
  - bash script 하나 만들고, Windows에서 사용 가능하게 만들어달라고 Claude 시켜서 powershell script 파일 만들었습니다. 보시고 테스트 부탁드려요.
- 퀴즈 이미지 
  - hello-world
    - 실행시키면 answer 출력합니다.
  - joke
    - 실행시키면 아재개그 냅니다.
  - 문제 설명 수정
    - 퀴즈 이미지에 맞게 content를 수정했습니다.
  - 참고
    - C언어 컴파일해서 실행파일 만들었습니다.

### 볼륨 마운트 및 이미지 Push 관련 보안 조치 추가

사용 가능한 이미지를 로컬 레지스트리로 제한해서 OS 이미지를 받을 일이 없을 것 같긴 한데, 혹시 모르니 볼륨 마운트 자체를 못하게 막았습니다.
11월 28일자로 결정된 바에 따라, 임시로 Push 커맨드도 제한합니다.
backend의 command validation pipe를 참고해주세요.

