### PR TITLE
탭 닫혔을 시 세션 해제 및 호스트 컨테이너 삭제 기능

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,7 +7,7 @@ import { QuizModule } from './quiz/quiz.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import { SandboxModule } from './sandbox/sandbox.module';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import {
     BusinessExceptionsFilter,
     HttpExceptionsFilter,
@@ -17,6 +17,8 @@ import { AuthModule } from './common/auth/auth.module';
 import { LoggerMiddleware } from './common/logger/middleware';
 import { ScheduleModule } from '@nestjs/schedule';
 import { RequestModule } from './common/request/request.module';
+import { RequestInterceptor } from './common/request/request.interceptor';
+import { CacheModule } from './common/cache/cache.module';
 
 @Module({
     imports: [
@@ -41,6 +43,7 @@ import { RequestModule } from './common/request/request.module';
         AuthModule,
         RequestModule,
         ScheduleModule.forRoot(),
+        CacheModule,
     ],
     controllers: [AppController],
     providers: [
@@ -58,6 +61,10 @@ import { RequestModule } from './common/request/request.module';
             useClass: BusinessExceptionsFilter,
         },
         Logger,
+        {
+            provide: APP_INTERCEPTOR,
+            useClass: RequestInterceptor,
+        },
     ],
 })
 export class AppModule implements NestModule {

--- a/backend/src/common/constant.ts
+++ b/backend/src/common/constant.ts
@@ -1,2 +1,2 @@
 export const SESSION_DURATION = 1000 * 60 * 60 * 4; // 4 hours
-export const NO_INTERACTION_TIME_LIMIT = 1000 * 60 * 60; // 1 hours
+export const NO_INTERACTION_TIME_LIMIT = 1000 * 60 * 30; // 30 minutes

--- a/backend/src/common/constant.ts
+++ b/backend/src/common/constant.ts
@@ -1,1 +1,2 @@
 export const SESSION_DURATION = 1000 * 60 * 60 * 4; // 4 hours
+export const NO_INTERACTION_TIME_LIMIT = 1000 * 60 * 60; // 1 hours

--- a/backend/src/common/request/request.interceptor.ts
+++ b/backend/src/common/request/request.interceptor.ts
@@ -1,0 +1,19 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { CacheService } from '../cache/cache.service';
+import { UserSession } from '../types/session';
+
+@Injectable()
+export class RequestInterceptor implements NestInterceptor {
+    constructor(private readonly cacheService: CacheService) {}
+    intercept(context: ExecutionContext, next: CallHandler) {
+        const request = context.switchToHttp().getRequest();
+        const sessionId = request.cookies['sid'];
+        const sessionDatas = this.cacheService.get(sessionId) as UserSession;
+        const currentTime = new Date();
+        this.cacheService.set(sessionId, {
+            ...sessionDatas,
+            lastRequest: currentTime,
+        });
+        return next.handle();
+    }
+}

--- a/backend/src/common/request/request.interceptor.ts
+++ b/backend/src/common/request/request.interceptor.ts
@@ -9,17 +9,16 @@ export class RequestInterceptor implements NestInterceptor {
         const request = context.switchToHttp().getRequest();
         const sessionId = request.cookies['sid'];
         if (
-            context.getClass().name === 'SandboxController' &&
-            context.getHandler().name === 'assignContainer'
+            context.getClass().name !== 'SandboxController' ||
+            context.getHandler().name !== 'assignContainer'
         ) {
-            return next.handle();
+          const sessionDatas = this.cacheService.get(sessionId) as UserSession;
+          const currentTime = new Date();
+          this.cacheService.set(sessionId, {
+              ...sessionDatas,
+              lastRequest: currentTime,
+          });
         }
-        const sessionDatas = this.cacheService.get(sessionId) as UserSession;
-        const currentTime = new Date();
-        this.cacheService.set(sessionId, {
-            ...sessionDatas,
-            lastRequest: currentTime,
-        });
         return next.handle();
     }
 }

--- a/backend/src/common/request/request.interceptor.ts
+++ b/backend/src/common/request/request.interceptor.ts
@@ -8,7 +8,12 @@ export class RequestInterceptor implements NestInterceptor {
     intercept(context: ExecutionContext, next: CallHandler) {
         const request = context.switchToHttp().getRequest();
         const sessionId = request.cookies['sid'];
-        if (sessionId) {
+        if (
+            !(
+                context.getClass().name === 'SandboxController' &&
+                context.getHandler().name === 'assignContainer'
+            )
+        ) {
             const sessionDatas = this.cacheService.get(sessionId) as UserSession;
             const currentTime = new Date();
             this.cacheService.set(sessionId, {

--- a/backend/src/common/request/request.interceptor.ts
+++ b/backend/src/common/request/request.interceptor.ts
@@ -9,18 +9,17 @@ export class RequestInterceptor implements NestInterceptor {
         const request = context.switchToHttp().getRequest();
         const sessionId = request.cookies['sid'];
         if (
-            !(
-                context.getClass().name === 'SandboxController' &&
-                context.getHandler().name === 'assignContainer'
-            )
+            context.getClass().name === 'SandboxController' &&
+            context.getHandler().name === 'assignContainer'
         ) {
-            const sessionDatas = this.cacheService.get(sessionId) as UserSession;
-            const currentTime = new Date();
-            this.cacheService.set(sessionId, {
-                ...sessionDatas,
-                lastRequest: currentTime,
-            });
+            return next.handle();
         }
+        const sessionDatas = this.cacheService.get(sessionId) as UserSession;
+        const currentTime = new Date();
+        this.cacheService.set(sessionId, {
+            ...sessionDatas,
+            lastRequest: currentTime,
+        });
         return next.handle();
     }
 }

--- a/backend/src/common/request/request.interceptor.ts
+++ b/backend/src/common/request/request.interceptor.ts
@@ -12,12 +12,12 @@ export class RequestInterceptor implements NestInterceptor {
             context.getClass().name !== 'SandboxController' ||
             context.getHandler().name !== 'assignContainer'
         ) {
-          const sessionDatas = this.cacheService.get(sessionId) as UserSession;
-          const currentTime = new Date();
-          this.cacheService.set(sessionId, {
-              ...sessionDatas,
-              lastRequest: currentTime,
-          });
+            const sessionDatas = this.cacheService.get(sessionId) as UserSession;
+            const currentTime = new Date();
+            this.cacheService.set(sessionId, {
+                ...sessionDatas,
+                lastRequest: currentTime,
+            });
         }
         return next.handle();
     }

--- a/backend/src/common/request/request.interceptor.ts
+++ b/backend/src/common/request/request.interceptor.ts
@@ -8,12 +8,14 @@ export class RequestInterceptor implements NestInterceptor {
     intercept(context: ExecutionContext, next: CallHandler) {
         const request = context.switchToHttp().getRequest();
         const sessionId = request.cookies['sid'];
-        const sessionDatas = this.cacheService.get(sessionId) as UserSession;
-        const currentTime = new Date();
-        this.cacheService.set(sessionId, {
-            ...sessionDatas,
-            lastRequest: currentTime,
-        });
+        if (sessionId) {
+            const sessionDatas = this.cacheService.get(sessionId) as UserSession;
+            const currentTime = new Date();
+            this.cacheService.set(sessionId, {
+                ...sessionDatas,
+                lastRequest: currentTime,
+            });
+        }
         return next.handle();
     }
 }

--- a/backend/src/common/request/request.module.ts
+++ b/backend/src/common/request/request.module.ts
@@ -2,11 +2,12 @@ import { Global, Module } from '@nestjs/common';
 import { RequestService } from './request.service';
 import { RequestGuard } from './request.guard';
 import { CacheModule } from '../cache/cache.module';
+import { RequestInterceptor } from '../request/request.interceptor';
 
 @Global()
 @Module({
     imports: [CacheModule],
-    providers: [RequestService, RequestGuard],
-    exports: [RequestGuard, RequestService],
+    providers: [RequestService, RequestGuard, RequestInterceptor],
+    exports: [RequestGuard, RequestService, RequestInterceptor],
 })
 export class RequestModule {}

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -51,12 +51,12 @@ export class SandboxController {
             const sessionData = await this.sandboxService.assignContainer(ipAddress);
             const startTime = sessionData?.startTime as Date;
             res.cookie('sid', sessionData?.sessionId, { httpOnly: true, maxAge: SESSION_DURATION });
-            res.json({ endDate: new Date(startTime).getTime() + SESSION_DURATION });
+            return { endDate: new Date(startTime).getTime() + SESSION_DURATION };
         } catch (error) {
             if (error instanceof SessionAlreadyAssignedException) {
                 const startTime = this.cacheService.get(hashedSessionID)?.startTime as Date;
                 res.cookie('sid', hashedSessionID, { httpOnly: true, maxAge: SESSION_DURATION });
-                res.json({ endDate: new Date(startTime).getTime() + SESSION_DURATION });
+                return { endDate: new Date(startTime).getTime() + SESSION_DURATION };
             } else {
                 throw error;
             }

--- a/backend/src/sandbox/sandbox.controller.ts
+++ b/backend/src/sandbox/sandbox.controller.ts
@@ -91,7 +91,7 @@ export class SandboxController {
     }
 
     @Delete('release')
-    @UseGuards(AuthGuard, RequestGuard)
+    @UseGuards(AuthGuard)
     releaseUserSession(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
         const sessionId = req.cookies['sid'];
         this.sandboxService.releaseUserSession(sessionId);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,10 +25,16 @@ const App = () => {
         AOS.init({
             duration: 500,
         });
-        window.addEventListener('beforeunload', (e: BeforeUnloadEvent) => {
+        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
             e.preventDefault();
             return '';
-        });
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+        };
     }, []);
 
     return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,6 @@ import { QuizPage } from './components/quiz/QuizPage';
 import { Alert } from 'flowbite-react';
 import { useAlert } from './hooks/useAlert';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { requestReleaseSession } from './api/quiz';
 
 const queryClient = new QueryClient();
 
@@ -29,9 +28,6 @@ const App = () => {
         window.addEventListener('beforeunload', (e: BeforeUnloadEvent) => {
             e.preventDefault();
             return '';
-        });
-        window.addEventListener('unload', () => {
-            requestReleaseSession();
         });
     }, []);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { QuizPage } from './components/quiz/QuizPage';
 import { Alert } from 'flowbite-react';
 import { useAlert } from './hooks/useAlert';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { requestReleaseSession } from './api/quiz';
 
 const queryClient = new QueryClient();
 
@@ -24,6 +25,13 @@ const App = () => {
     useEffect(() => {
         AOS.init({
             duration: 500,
+        });
+        window.addEventListener('beforeunload', (e: BeforeUnloadEvent) => {
+            e.preventDefault();
+            return '';
+        });
+        window.addEventListener('unload', () => {
+            requestReleaseSession();
         });
     }, []);
 

--- a/frontend/src/api/quiz.ts
+++ b/frontend/src/api/quiz.ts
@@ -143,10 +143,10 @@ export const requestQuizAccessability = async (quizId: number) => {
     }
 };
 
-export const requestReleaseSession = async (navigate: NavigateFunction) => {
+export const requestReleaseSession = async (navigate?: NavigateFunction) => {
     try {
         await axios.delete(`/api/sandbox/release`);
     } catch (error) {
-        return handleErrorResponse(error, navigate);
+        if (navigate) return handleErrorResponse(error, navigate);
     }
 };

--- a/frontend/src/components/StartButton.tsx
+++ b/frontend/src/components/StartButton.tsx
@@ -14,7 +14,6 @@ const StartButton = (props: StartButtonProps) => {
     const handleButtonClick = async () => {
         setLoading(true);
         const endDate = await createHostContainer(navigate);
-        console.log(endDate);
         if (endDate) {
             setLoading(false);
             setMaxAge(new Date(endDate).getTime());

--- a/frontend/src/components/StartButton.tsx
+++ b/frontend/src/components/StartButton.tsx
@@ -14,6 +14,7 @@ const StartButton = (props: StartButtonProps) => {
     const handleButtonClick = async () => {
         setLoading(true);
         const endDate = await createHostContainer(navigate);
+        console.log(endDate);
         if (endDate) {
             setLoading(false);
             setMaxAge(new Date(endDate).getTime());


### PR DESCRIPTION
## 작업 개요

- Resolves #251 

## 작업 상세 내용

### 사용자가 웹 브라우저의 탭을 닫을 시 사용자 세션 제거 및 호스트 컨테이너 삭제

웹 브라우저의 `unload`이벤트를 활용하여 해당 이벤트가 발생하면, Proxy Server에게 사용자의 세션과 호스트 컨테이너를 해제 해달라는 요청을 보내도록 구현

### Request Interceptor구현

위의 `unload`이벤트의 경우 원하는 동작이 온전히 이루어지지 않는 이슈와 전송 데이터의 보장이 이루어지지 않아 `deprecated`된 기능입니다.

이에 따라, 웹 브라우저의 환경에 따라서 해당 이벤트가 적용이 되지 않는 경우가 있을 것입니다. 이런 경우에 사용자가 사용하던 세션과 호스트 컨테이너는 종료되지 않기 때문에 4시간이 지나야 정리가 됩니다.

위의 문제를 해결하기 위해서 적용하려는 방법은 `Request Interceptor`를 통해 `start`를 제외한 Session이 있는 클라이언트에 대해서 세션 테이블에 마지막 API요청 시간을 기록하도록 하였습니다. 기록된 시간 데이터는 이후 청소기가 돌아갈 때 `청소기가 돌아가는 시간 - 마지막 요청 시간`이 30분이 넘어간다면, 해당 세션은 지우고 세션에 할당된 호스트 컨테이너 또한 삭제합니다.

### 웹 브라우저에 세션이 없고, 서버에 세션이 있는 경우

웹 브라우저에 세션은 쿠키에 저장합니다. 사용자가 쿠키를 지운 경우 서버에서는 해당 세션은 여전히 유효하기 때문에 해당 사용자가 다시 학습 시작버튼을 눌러도 이전 세션 정보를 바탕으로 타이머가 다시 보여야 합니다. 하지만, `Loading`만 계속될 뿐 Timer가 실행되지 않았습니다.

결론적으로 `SandboxController`에서 `SessionAlreadyAssignedException`인 경우 endDate를 응답하지 않는 문제가 있었고, 해당 데이터를 응답하도록 수정하였습니다.

## 참고자료(선택)

- [NestJS Interceptor](https://docs.nestjs.com/interceptors)
- [5주 6일차 개발 일지](https://github.com/boostcampwm-2024/web34-LearnDocker/wiki/%5B5%EC%A3%BC-6%EC%9D%BC%EC%B0%A8-%E2%80%90-J048-%EA%B9%80%EC%98%81%EA%B4%80%5D-%EA%B0%9C%EB%B0%9C-%EC%9D%BC%EC%A7%80%28%ED%83%AD-%EB%8B%AB%EC%9D%84-%EC%8B%9C-%EC%84%B8%EC%85%98-%ED%95%B4%EC%A0%9C-%EB%B0%8F-%EC%84%B8%EC%85%98-%EA%B4%80%EB%A6%AC2%29)

## 문제점 혹은 고민(선택)

- 학습 시작 버튼을 누르고, 쿠키를 삭제한 후 퀴즈를 풀러 가면 `학습 시작 버튼을 누르세요`라는 alert이 표시된다. 사실 이런 경우에는 쿠키가 없어졌기 때문에 다시 `학습 시작 버튼`을 보여야 하는게 아닌가? 생각이 든다.