### PR TITLE
nginx 설정을 적용하기 위해 trust proxy를 true로 추가

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,16 +1,18 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { winstonConfig } from './common/logger/config';
 import { WinstonModule } from 'nest-winston';
-import cookieParser from 'cookie-parser'
+import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
-    const app = await NestFactory.create(AppModule, {
+    const app = await NestFactory.create<NestExpressApplication>(AppModule, {
         logger: WinstonModule.createLogger(winstonConfig),
         bufferLogs: true,
     });
+    app.set('trust proxy', true);
     app.use(cookieParser());
-    app.setGlobalPrefix('api')
+    app.setGlobalPrefix('api');
     await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
## 작업 개요

- closes #322 

## 작업 상세 내용

- [x] req.ip로 사용자 ip에 접근하기 위해 'trust proxy' 설정을 true로 set
- [x] main.ts에서 type error를 해결하기 위해 NestExpressApplication 임포트

## Nginx 설정 오류 해결

### 문제 상황

- 현재 nest 서버에서 사용자의 IP를 기반으로 SID를 생성하고 발급하기 있는데, Nginx 서버를 한번 거치게 되면서 req.ip가 사용자의 ip가 아니라 nginx의 ip로 설정되는 문제

### 문제 해결

- Nginx 설정에서 X-Forwarded-For 헤더를 설정하여 클라이언트의 ip를 사용할 수 있도록 수정

[/etc/nginx/nginx.conf]
```bash
location / {
    proxy_pass http://localhost:3000;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header Host $host;
}
```


## 참고자료

## 문제점 혹은 고민