### PR TITLE
컨테이너 실행 및 중지 커스텀 이미지 수정, 로그 퀴즈 추가, 커맨드 유효성 검사 추가

### DIFF
--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -33,7 +33,7 @@ export class QuizService {
                     'learndocker.io에서 제공하는 hello-world 이미지를 가져와보세요.\n\n' +
                     '1. docker pull 명령어를 사용하여 hello-world 이미지를 다운로드하세요.\n' +
                     '2. 이미지가 성공적으로 다운로드되면 자동으로 로컬 시스템에 저장됩니다.\n\n' +
-                    '힌트: docker pull <이미지명> 형식으로 명령어를 작성하세요.\n' +
+                    '힌트: docker pull <learndocker.io/이미지명> 형식으로 명령어를 작성하세요.\n' +
                     '힌트: 특정 레지스트리에서 이미지를 가져올 때는 이미지명 앞에 <레지스트리 주소/>를 붙여주세요.',
             },
             {
@@ -50,17 +50,17 @@ export class QuizService {
                 title: 'Docker Image 삭제하기',
                 content:
                     '더 이상 필요하지 않은 Docker 이미지를 삭제하는 방법을 알아봅시다.\n\n' +
-                    '1. docker rmi 명령어를 사용하여 hello-world 이미지를 삭제하세요.\n' +
+                    '1. docker rmi 명령어를 사용하여 learndocker.io/hello-world 이미지를 삭제하세요.\n' +
                     '2. 삭제 후 docker images 명령어로 이미지가 정상적으로 삭제되었는지 확인하세요.\n\n' +
-                    '힌트: docker rmi <이미지명> 형식으로 명령어를 작성하세요.',
+                    '힌트: docker rmi <learndocker.io/이미지명 | IMAGE ID> 형식으로 명령어를 작성하세요.',
             },
             {
                 id: 4,
                 title: 'Container 생성하기',
                 content:
                     'Docker 이미지를 기반으로 컨테이너를 생성해봅시다.\n\n' +
-                    '1. docker create 명령어를 사용하여 hello-world 이미지로부터 컨테이너를 생성하세요.\n\n' +
-                    '힌트: docker create <이미지명> 형식으로 명령어를 작성하세요.',
+                    '1. docker create 명령어를 사용하여 learndocker.io/hello-world 이미지로부터 컨테이너를 생성하세요.\n\n' +
+                    '힌트: docker create <learndocker.io/이미지명> 형식으로 명령어를 작성하세요.',
             },
             {
                 id: 5,
@@ -71,6 +71,7 @@ export class QuizService {
                     '2. 컨테이너 ID나 이름을 사용하여 실행할 수 있습니다.\n' +
                     '3. 실행 후 터미널에 표시되는 "Answer: " 다음에 나오는 값을 입력해주세요.\n\n' +
                     '힌트: docker start -a <컨테이너ID> 형식으로 명령어를 작성하세요.\n' +
+                    '힌트: docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.\n' +
                     '힌트: 컨테이너ID 전부 적을 필요는 없습니다.',
             },
             {
@@ -78,14 +79,25 @@ export class QuizService {
                 title: 'Container 생성 및 실행하기',
                 content:
                     '컨테이너의 생성과 실행을 한 번에 수행해봅시다.\n\n' +
-                    '1. docker run 명령어를 사용하여 joke 이미지로 컨테이너를 생성하고 실행하세요.\n' +
-                    '2. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n' +
-                    '3. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n\n' +
-                    '힌트: docker run <이미지명> 형식으로 명령어를 작성하세요.\n' +
+                    '1. docker run 명령어를 사용하여 learndocker.io/joke 이미지로 컨테이너를 생성하고 실행하세요.\n' +
+                    '2. 단 detach 모드로 실행해야 합니다.\n' +
+                    '3. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n' +
+                    '4. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n\n' +
+                    '힌트: docker run --detach <이미지명 | IMAGE ID> 형식으로 명령어를 작성하세요.\n' +
                     '힌트: 이미지는 learndocker.io/joke를 사용하세요.',
             },
             {
                 id: 7,
+                title: 'Container 로그 확인하기',
+                content:
+                    'detach로 실행 된 container 로그를 확인해보겠습니다.\n\n' +
+                    '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n' +
+                    '2. learndocker.io/joke 컨테이너의 로그를 확인하세요\n' +
+                    '3. 실행 후 터미널에 표시되는 문제를 보고 한글로 답을 입력해주세요.\n\n' +
+                    '힌트: docker logs <CONTAINER ID | NAMES>을 사용하세요',
+            },
+            {
+                id: 8,
                 title: 'Container 목록 확인하기',
                 content:
                     '실행 중이거나 중지된 모든 컨테이너를 확인해봅시다.\n\n' +
@@ -94,7 +106,7 @@ export class QuizService {
                     '힌트: docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.',
             },
             {
-                id: 8,
+                id: 9,
                 title: 'Container 중지하기',
                 content:
                     '실행 중인 컨테이너를 중지해보겠습니다.\n\n' +
@@ -104,7 +116,7 @@ export class QuizService {
                     '힌트: 컨테이너ID 전부 적을 필요는 없습니다.',
             },
             {
-                id: 9,
+                id: 10,
                 title: 'Container 삭제하기',
                 content:
                     '더 이상 필요하지 않은 컨테이너를 삭제해봅시다.\n\n' +
@@ -163,17 +175,20 @@ export class QuizService {
                 //컨테이너 실행하기
                 return this.submitQuiz5(sessionId, userAnswer, level);
             case 6:
-                //컨테이너 생성및 실행하기
-                return this.submitQuiz6(sessionId, userAnswer, level);
+                //컨테이너 생성 및 실행하기
+                return this.submitQuiz6(sessionId, containerPort, level);
             case 7:
-                //컨테이너 목록 확인하기
-                return this.submitQuiz7(sessionId, containerPort, userAnswer, level);
+                //컨테이너 로그 확인하기
+                return this.submitQuiz7(sessionId, userAnswer, level);
             case 8:
-                //컨테이너 중지하기
-                return this.submitQuiz8(sessionId, containerPort, level);
+                //컨테이너 목록 확인하기
+                return this.submitQuiz8(sessionId, containerPort, userAnswer, level);
             case 9:
-                //컨테이너 삭제하기
+                //컨테이너 중지하기
                 return this.submitQuiz9(sessionId, containerPort, level);
+            case 10:
+                //컨테이너 삭제하기
+                return this.submitQuiz10(sessionId, containerPort, level);
             default:
                 throw new MethodNotAllowedException(`${quizId}번 퀴즈는 아직 채점할 수 없습니다.`);
         }
@@ -258,11 +273,18 @@ export class QuizService {
         }
     }
 
-    private async submitQuiz6(sessionId: string, userAnswer: string | undefined, level: number) {
-        // TODO: 커스텀 이미지 만들고 answer 수정해야함
-        const answer = 'hello-world';
+    private async submitQuiz6(sessionId: string, containerPort: string, level: number) {
+        const validImage = ['learndocker.io/joke'];
+        const containers = await this.sandboxService.getUserContainers(containerPort);
+        if (containers.length === 0) {
+            return { quizResult: 'FAIL' };
+        }
 
-        if (userAnswer === answer) {
+        const result = containers.every((container: Record<string, any>) => {
+            return container.State === 'running' && validImage.includes(container.Image);
+        });
+
+        if (result) {
             this.updateLevel(sessionId, level, 7);
             return { quizResult: 'SUCCESS' };
         } else {
@@ -270,7 +292,18 @@ export class QuizService {
         }
     }
 
-    private async submitQuiz7(
+    private async submitQuiz7(sessionId: string, userAnswer: string | undefined, level: number) {
+        const answer = '스페이스바';
+
+        if (userAnswer?.trim() === answer) {
+            this.updateLevel(sessionId, level, 8);
+            return { quizResult: 'SUCCESS' };
+        } else {
+            return { quizResult: 'FAIL' };
+        }
+    }
+
+    private async submitQuiz8(
         sessionId: string,
         containerPort: string,
         userAnswer: string | undefined,
@@ -286,23 +319,6 @@ export class QuizService {
         );
 
         if (result.length > 0) {
-            this.updateLevel(sessionId, level, 8);
-            return { quizResult: 'SUCCESS' };
-        } else {
-            return { quizResult: 'FAIL' };
-        }
-    }
-
-    private async submitQuiz8(sessionId: string, containerPort: string, level: number) {
-        const containers = await this.sandboxService.getUserContainers(containerPort);
-        if (containers.length === 0) {
-            return { quizResult: 'FAIL' };
-        }
-
-        const result = containers.every(
-            (container: Record<string, any>) => container.State === 'exited'
-        );
-        if (result) {
             this.updateLevel(sessionId, level, 9);
             return { quizResult: 'SUCCESS' };
         } else {
@@ -312,9 +328,26 @@ export class QuizService {
 
     private async submitQuiz9(sessionId: string, containerPort: string, level: number) {
         const containers = await this.sandboxService.getUserContainers(containerPort);
+        if (containers.length === 0) {
+            return { quizResult: 'FAIL' };
+        }
+
+        const result = containers.every(
+            (container: Record<string, any>) => container.State === 'exited'
+        );
+        if (result) {
+            this.updateLevel(sessionId, level, 10);
+            return { quizResult: 'SUCCESS' };
+        } else {
+            return { quizResult: 'FAIL' };
+        }
+    }
+
+    private async submitQuiz10(sessionId: string, containerPort: string, level: number) {
+        const containers = await this.sandboxService.getUserContainers(containerPort);
 
         if (containers.length === 0) {
-            this.updateLevel(sessionId, level, 10);
+            this.updateLevel(sessionId, level, 11);
             return { quizResult: 'SUCCESS' };
         } else {
             return { quizResult: 'FAIL' };

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -280,7 +280,7 @@ export class QuizService {
             return { quizResult: 'FAIL' };
         }
 
-        const result = containers.every((container: Record<string, any>) => {
+        const result = containers.some((container: Record<string, any>) => {
             return container.State === 'running' && validImage.includes(container.Image);
         });
 

--- a/backend/src/sandbox/pipes/command.pipe.spec.ts
+++ b/backend/src/sandbox/pipes/command.pipe.spec.ts
@@ -10,6 +10,7 @@ describe('CommandValidationPipe', () => {
             providers: [CommandValidationPipe],
         }).compile();
         pipe = module.get<CommandValidationPipe>(CommandValidationPipe);
+        process.env.JOKE_IMAGE_ID = 'e970cf9c277f';
     });
 
     it.each([
@@ -42,5 +43,30 @@ describe('CommandValidationPipe', () => {
         'docker rm hello-world',
     ])('Valid user command test', (command: string) => {
         expect(pipe.transform(command)).toEqual(command);
+    });
+
+    describe('Joke Image ID tests', () => {
+        it.each([
+            'docker run -d learndocker.io/joke',
+            'docker run --detach learndocker.io/joke',
+            'docker run -d -p 8080 e',
+            'docker run -d e97',
+            'docker run --detach -p 8080 e970cf9c277f',
+            'docker run -d e970',
+        ])('Valid joke image command test with detach option', (command: string) => {
+            expect(pipe.transform(command)).toEqual(command);
+        });
+
+        it.each([
+            'docker run learndocker.io/joke',
+            'docker run e',
+            'docker run e97',
+            'docker run -p 8080 e970cf9c277f',
+            'docker run e970',
+        ])('Invalid joke image command test without detach option', (command: string) => {
+            expect(() => {
+                pipe.transform(command);
+            }).toThrow(BadRequestException);
+        });
     });
 });

--- a/backend/src/sandbox/pipes/command.pipe.ts
+++ b/backend/src/sandbox/pipes/command.pipe.ts
@@ -1,9 +1,12 @@
 import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
 
-const VALID_REGEX = /^docker\s(?:(?!.*\b(?:sh|bash|exec)\b|.*[;&|<>$`]))/;
+const VALID_REGEX = /^docker\s(?:(?!.*\b(?:sh|bash|exec|tag|commit)\b|.*[;&|<>$`]))/;
 const VOLUME_MOUNT_CHECK_REGEX =
     /^docker\s+(?:(?:container\s+)?(?:create|run))\s+.*(?:-v\b|--volume\b)/;
 const PUSH_CHECK_REGEX = /^docker\s+(?:(?:image\s+)?(?:push))/;
+const DOCKER_RUN_CHECK_REGEX = /^docker\s+(?:(?:container\s+)?(?:run))/;
+const DETACH_OPTION_REGEX = /(?:-d\b|--detach\b)/;
+const JOKE_IMAGE_NAME = 'learndocker.io/joke';
 
 @Injectable()
 export class CommandValidationPipe implements PipeTransform {
@@ -14,7 +17,33 @@ export class CommandValidationPipe implements PipeTransform {
         const pushCheck = PUSH_CHECK_REGEX.test(value);
         const isValid = baseValidation && !volumeMountCheck && !pushCheck;
 
-        if (!isValid) throw new BadRequestException('해당 명령어는 사용이 불가능합니다!');
+        if (!isValid) {
+            throw new BadRequestException('해당 명령어는 사용이 불가능합니다!');
+        }
+
+        const runImage = DOCKER_RUN_CHECK_REGEX.test(value);
+        if (runImage && this.isJokeImage(value)) {
+            const hasDetachOption = DETACH_OPTION_REGEX.test(value);
+            if (!hasDetachOption) {
+                throw new BadRequestException(
+                    'joke 이미지는 detach 옵션(-d 또는 --detach)과 함께 실행해야 합니다!'
+                );
+            }
+        }
+
         return value;
+    }
+
+    private isJokeImage(commands: string): boolean {
+        const jokeImageId = process.env.JOKE_IMAGE_ID;
+
+        if (commands.includes(JOKE_IMAGE_NAME)) {
+            return true;
+        }
+        if (jokeImageId && commands.split(' ').some((command) => jokeImageId.startsWith(command))) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -25,9 +25,10 @@ const dockerContainerLinks = [
     { title: 'Container 생성하기', path: '/quiz/4' },
     { title: 'Container 실행하기', path: '/quiz/5' },
     { title: 'Container 생성 및 실행하기', path: '/quiz/6' },
-    { title: 'Container 목록 확인하기', path: '/quiz/7' },
-    { title: 'Container 중지하기', path: '/quiz/8' },
-    { title: 'Container 삭제하기', path: '/quiz/9' },
+    { title: 'Container 로그 확인하기', path: '/quiz/7' },
+    { title: 'Container 목록 확인하기', path: '/quiz/8' },
+    { title: 'Container 중지하기', path: '/quiz/9' },
+    { title: 'Container 삭제하기', path: '/quiz/10' },
 ];
 
 const SidebarSection = ({ title, links }: SidebarSectionProps) => {

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -41,7 +41,7 @@ const QuizButtons = ({ quizNumber, answer, showAlert }: QuizButtonsProps) => {
     };
 
     const handleNextButtonClick = async () => {
-        if (quizNumber > 8) {
+        if (quizNumber > 9) {
             showAlert('마지막 문제입니다.');
             return;
         }

--- a/frontend/src/components/quiz/QuizPageWrapper.tsx
+++ b/frontend/src/components/quiz/QuizPageWrapper.tsx
@@ -17,7 +17,7 @@ export const QuizPageWrapper = ({ children, showAlert }: QuizPageWrapperProps) =
         const validateQuiz = async () => {
             const quizNumber = Number(quizId);
 
-            if (Number.isNaN(quizNumber) || quizNumber < 1 || quizNumber > 9) {
+            if (Number.isNaN(quizNumber) || quizNumber < 1 || quizNumber > 10) {
                 navigate('/error/404');
                 return;
             }

--- a/frontend/src/constant/quiz.ts
+++ b/frontend/src/constant/quiz.ts
@@ -1,1 +1,1 @@
-export const CUSTOM_QUIZZES: readonly number[] = [2, 5, 6, 7];
+export const CUSTOM_QUIZZES: readonly number[] = [2, 5, 7, 8];

--- a/sandbox/quiz-images/joke/joke.c
+++ b/sandbox/quiz-images/joke/joke.c
@@ -1,12 +1,32 @@
-#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+
+static sig_atomic_t running = 1;
+
+void signal_handler(int signum) {
+    if (signum == SIGTERM) {
+        running = 0;
+    }
+}
+
+size_t strlen(const char *str) {
+    const char *s;
+    for (s = str; *s; ++s)
+        ;
+    return s - str;
+}
 
 int main() {
-    printf("넌센스 퀴즈입니다!\n");
-    printf("우주인이 술 마시는 장소는?\n");
+    signal(SIGTERM, signal_handler);
 
-    while(1) {
+    const char *msg = "넌센스 퀴즈입니다!\n우주인이 술 마시는 장소는?\n";
+
+    write(STDOUT_FILENO, msg, strlen(msg));
+
+    while(running) {
         sleep(2);
     }
+    
     
     return 0;
 }


### PR DESCRIPTION
## 작업 개요
- #313 
- #317 
## 작업 상세 내용
### 커맨드 유효성 검사 추가
- 저희가 원했던 사용자가 detach 옵션을 붙이지 않더라도 백그라운드로 실행 되며 사용자에게 퀴즈 내용을 알려주는 이미지를 만드는 것은 불가능하다고 생각 했습니다.
- 사용자에게 detach 옵션을 붙이도록 하고 안 붙였을 경우 명령창에 메시지로 'joke 이미지는 detach 옵션(-d 또는 --detach)과 함께 실행해야 합니다!' 알려주려고 합니다.
- docker run이면서 learndocker.io/joke이거나 joke의 이미지 아이디인 경우 detach 옵션이 붙어있는지 검사하는 로직을 추가 했습니다.
- tag, commit으로 도커 이미지 이름을 바꿀 수 있기 때문에 검사하는 로직을 추가했습니다.
<img width="615" alt="이미지_이름_02" src="https://github.com/user-attachments/assets/851b53a3-d3e8-4e16-8215-ed6c55370e9a">
<img width="826" alt="이미지_이름_01" src="https://github.com/user-attachments/assets/9c303e41-e76b-4420-82ae-b8b02283ad2f">

### 로그 퀴즈 추가
- 컨테이너 실행 및 확인 하기에서 detach 모드로 실행하기 때문에 퀴즈 내용을 보려면 log를 확인해야 합니다
- 로그를 확인해서 퀴즈의 정답을 맞추는 것 까지 컨테이너 실행 및 확인하기에 들어가는 것은 퀴즈 내용이 많다고 판단했습니다.
- 컨테이너 실행 및 확인 하기는 joke 컨테이너 상태가 running인지 확인 하고 퀴즈 답은 로그 퀴즈에서 확인 하도록 했습니다.
### 커스텀 joke 이미지 수정
- 커스텀 이미지 중 joke의 컨테이너 중지 명령어 실행 시 응답 대기 시간이 10초를 초과하여 타임아웃이 발생하는 문제가 있었습니다. 이는 배포 환경뿐만 아니라 로컬 환경에서도 동일하게 발생했습니다.
- Docker의 컨테이너 종료 프로세스를 분석한 결과, SIGTERM 신호를 처리하지 못하면 SIGKILL을 보낸다는 것을 알게 되었습니다. joke Dockerfile에 SIGTERM 시그널 핸들링을 구현하여 정상적인 종료가 가능하도록 해결했습니다.
