### PR TITLE
input 창과 버튼 정렬, 숨겨진 힌트를 드러내는 버튼 추가, input창 위치를 언급하는 설명 추가

### DIFF
--- a/backend/src/quiz/quiz.entity.ts
+++ b/backend/src/quiz/quiz.entity.ts
@@ -10,4 +10,7 @@ export class Quiz {
 
     @Column('varchar', { length: 500 })
     content: string;
+
+    @Column('varchar', { length: 500, nullable: true })
+    hint?: string;
 }

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -45,7 +45,8 @@ export class QuizService {
                 content:
                     '로컬 시스템에 저장된 Docker 이미지들을 확인해볼까요?\n\n' +
                     '1. docker images 명령어를 사용하여 현재 시스템에 있는 모든 Docker 이미지를 조회하세요.\n' +
-                    '2. 명령어 실행 후 출력된 결과에서 learndocker.io/hello-world 이미지 ID를 앞 4자리 이상 입력하세요.\n',
+                    '2. 명령어 실행 후 출력된 결과에서 learndocker.io/hello-world 이미지 ID를 앞 4자리 이상 입력하세요.\n' +
+                    '3. 답안란은 페이지 우측 하단에 있습니다.\n',
                 hint: `<ul class="list-disc list-inside">
   <li>이미지 목록을 확인하는 명령어는 별도의 인자가 필요하지 않습니다.</li>
 </ul>
@@ -81,7 +82,8 @@ export class QuizService {
                     '생성된 컨테이너를 실행해보겠습니다.\n\n' +
                     '1. docker start 명령어를 사용하여 이전 단계에서 생성한 컨테이너를 실행하세요.\n' +
                     '2. 컨테이너 ID나 이름을 사용하여 실행할 수 있습니다.\n' +
-                    '3. 실행 후 터미널에 표시되는 "Answer: " 다음에 나오는 값을 입력해주세요.\n',
+                    '3. 실행 후 터미널에 표시되는 "Answer: " 다음에 나오는 값을 입력해주세요.\n' +
+                    '4. 답안란은 페이지 우측 하단에 있습니다.\n',
                 hint: `<ul class="list-disc list-inside">
   <li>docker start -a <컨테이너ID> 형식으로 명령어를 작성하세요.</li>
   <li>docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.</li>
@@ -97,7 +99,8 @@ export class QuizService {
                     '1. docker run 명령어를 사용하여 learndocker.io/joke 이미지로 컨테이너를 생성하고 실행하세요.\n' +
                     '2. 단 detach 모드로 실행해야 합니다.\n' +
                     '3. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n' +
-                    '4. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n',
+                    '4. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n' +
+                    '5. 답안란은 페이지 우측 하단에 있습니다.\n',
                 hint: `<ul class="list-disc list-inside">
   <li>docker run --detach <이미지명 | IMAGE ID> 형식으로 명령어를 작성하세요.</li>
   <li>이미지는 learndocker.io/joke를 사용하세요.</li>
@@ -111,7 +114,8 @@ export class QuizService {
                     'detach로 실행 된 container 로그를 확인해보겠습니다.\n\n' +
                     '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n' +
                     '2. learndocker.io/joke 컨테이너의 로그를 확인하세요\n' +
-                    '3. 실행 후 터미널에 표시되는 문제를 보고 한글로 답을 입력해주세요.\n',
+                    '3. 실행 후 터미널에 표시되는 문제를 보고 한글로 답을 입력해주세요.\n' +
+                    '4. 답안란은 페이지 우측 하단에 있습니다.\n',
                 hint: `<ul class="list-disc list-inside">
   <li>docker logs <CONTAINER ID | NAMES>을 사용하세요.</li>
 </ul>
@@ -123,7 +127,8 @@ export class QuizService {
                 content:
                     '실행 중이거나 중지된 모든 컨테이너를 확인해봅시다.\n\n' +
                     '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n' +
-                    '2. joke 이미지로 만든 컨테이너의 ID 최소 앞 4자리를 입력하세요.\n',
+                    '2. joke 이미지로 만든 컨테이너의 ID 최소 앞 4자리를 입력하세요.\n' +
+                    '3. 답안란은 페이지 우측 하단에 있습니다.\n',
                 hint: `<ul class="list-disc list-inside">
   <li>docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.</li>
 </ul>

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -31,7 +31,7 @@ export class QuizService {
                 content:
                     'Docker의 첫 걸음을 시작해볼까요?\n' +
                     'learndocker.io에서 제공하는 hello-world 이미지를 가져와보세요.\n\n' +
-                    '1. docker pull 명령어를 사용하여 hello-world 이미지를 다운로드하세요.\n' +
+                    '1. docker pull 명령어를 사용하여 learndocker.io/hello-world 이미지를 다운로드하세요.\n' +
                     '2. 이미지가 성공적으로 다운로드되면 자동으로 로컬 시스템에 저장됩니다.\n',
                 hint: `<ul class="list-disc list-inside">
   <li>docker pull <learndocker.io/이미지명> 형식으로 명령어를 작성하세요.</li>

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -32,9 +32,12 @@ export class QuizService {
                     'Docker의 첫 걸음을 시작해볼까요?\n' +
                     'learndocker.io에서 제공하는 hello-world 이미지를 가져와보세요.\n\n' +
                     '1. docker pull 명령어를 사용하여 hello-world 이미지를 다운로드하세요.\n' +
-                    '2. 이미지가 성공적으로 다운로드되면 자동으로 로컬 시스템에 저장됩니다.\n\n' +
-                    '힌트: docker pull <learndocker.io/이미지명> 형식으로 명령어를 작성하세요.\n' +
-                    '힌트: 특정 레지스트리에서 이미지를 가져올 때는 이미지명 앞에 <레지스트리 주소/>를 붙여주세요.',
+                    '2. 이미지가 성공적으로 다운로드되면 자동으로 로컬 시스템에 저장됩니다.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>docker pull <learndocker.io/이미지명> 형식으로 명령어를 작성하세요.</li>
+  <li>특정 레지스트리에서 이미지를 가져올 때는 이미지명 앞에 <레지스트리 주소/>를 붙여주세요.</li>
+</ul>
+                `,
             },
             {
                 id: 2,
@@ -42,8 +45,11 @@ export class QuizService {
                 content:
                     '로컬 시스템에 저장된 Docker 이미지들을 확인해볼까요?\n\n' +
                     '1. docker images 명령어를 사용하여 현재 시스템에 있는 모든 Docker 이미지를 조회하세요.\n' +
-                    '2. 명령어 실행 후 출력된 결과에서 learndocker.io/hello-world 이미지 ID를 앞 4자리 이상 입력하세요.\n\n' +
-                    '힌트: 이미지 목록을 확인하는 명령어는 별도의 인자가 필요하지 않습니다.',
+                    '2. 명령어 실행 후 출력된 결과에서 learndocker.io/hello-world 이미지 ID를 앞 4자리 이상 입력하세요.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>이미지 목록을 확인하는 명령어는 별도의 인자가 필요하지 않습니다.</li>
+</ul>
+                `,
             },
             {
                 id: 3,
@@ -51,16 +57,22 @@ export class QuizService {
                 content:
                     '더 이상 필요하지 않은 Docker 이미지를 삭제하는 방법을 알아봅시다.\n\n' +
                     '1. docker rmi 명령어를 사용하여 learndocker.io/hello-world 이미지를 삭제하세요.\n' +
-                    '2. 삭제 후 docker images 명령어로 이미지가 정상적으로 삭제되었는지 확인하세요.\n\n' +
-                    '힌트: docker rmi <learndocker.io/이미지명 | IMAGE ID> 형식으로 명령어를 작성하세요.',
+                    '2. 삭제 후 docker images 명령어로 이미지가 정상적으로 삭제되었는지 확인하세요.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>docker rmi <learndocker.io/이미지명 | IMAGE ID> 형식으로 명령어를 작성하세요.</li>
+</ul>
+                `,
             },
             {
                 id: 4,
                 title: 'Container 생성하기',
                 content:
                     'Docker 이미지를 기반으로 컨테이너를 생성해봅시다.\n\n' +
-                    '1. docker create 명령어를 사용하여 learndocker.io/hello-world 이미지로부터 컨테이너를 생성하세요.\n\n' +
-                    '힌트: docker create <learndocker.io/이미지명> 형식으로 명령어를 작성하세요.',
+                    '1. docker create 명령어를 사용하여 learndocker.io/hello-world 이미지로부터 컨테이너를 생성하세요.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>docker create <learndocker.io/이미지명> 형식으로 명령어를 작성하세요.</li>
+</ul>
+                `,
             },
             {
                 id: 5,
@@ -69,10 +81,13 @@ export class QuizService {
                     '생성된 컨테이너를 실행해보겠습니다.\n\n' +
                     '1. docker start 명령어를 사용하여 이전 단계에서 생성한 컨테이너를 실행하세요.\n' +
                     '2. 컨테이너 ID나 이름을 사용하여 실행할 수 있습니다.\n' +
-                    '3. 실행 후 터미널에 표시되는 "Answer: " 다음에 나오는 값을 입력해주세요.\n\n' +
-                    '힌트: docker start -a <컨테이너ID> 형식으로 명령어를 작성하세요.\n' +
-                    '힌트: docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.\n' +
-                    '힌트: 컨테이너ID 전부 적을 필요는 없습니다.',
+                    '3. 실행 후 터미널에 표시되는 "Answer: " 다음에 나오는 값을 입력해주세요.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>docker start -a <컨테이너ID> 형식으로 명령어를 작성하세요.</li>
+  <li>docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.</li>
+  <li>컨테이너ID 전부 적을 필요는 없습니다.</li>
+</ul>
+                `,
             },
             {
                 id: 6,
@@ -82,9 +97,12 @@ export class QuizService {
                     '1. docker run 명령어를 사용하여 learndocker.io/joke 이미지로 컨테이너를 생성하고 실행하세요.\n' +
                     '2. 단 detach 모드로 실행해야 합니다.\n' +
                     '3. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n' +
-                    '4. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n\n' +
-                    '힌트: docker run --detach <이미지명 | IMAGE ID> 형식으로 명령어를 작성하세요.\n' +
-                    '힌트: 이미지는 learndocker.io/joke를 사용하세요.',
+                    '4. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>docker run --detach <이미지명 | IMAGE ID> 형식으로 명령어를 작성하세요.</li>
+  <li>이미지는 learndocker.io/joke를 사용하세요.</li>
+</ul>
+                `,
             },
             {
                 id: 7,
@@ -93,8 +111,11 @@ export class QuizService {
                     'detach로 실행 된 container 로그를 확인해보겠습니다.\n\n' +
                     '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n' +
                     '2. learndocker.io/joke 컨테이너의 로그를 확인하세요\n' +
-                    '3. 실행 후 터미널에 표시되는 문제를 보고 한글로 답을 입력해주세요.\n\n' +
-                    '힌트: docker logs <CONTAINER ID | NAMES>을 사용하세요',
+                    '3. 실행 후 터미널에 표시되는 문제를 보고 한글로 답을 입력해주세요.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>docker logs <CONTAINER ID | NAMES>을 사용하세요.</li>
+</ul>
+                `,
             },
             {
                 id: 8,
@@ -102,8 +123,11 @@ export class QuizService {
                 content:
                     '실행 중이거나 중지된 모든 컨테이너를 확인해봅시다.\n\n' +
                     '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n' +
-                    '2. joke 이미지로 만든 컨테이너의 ID 최소 앞 4자리를 입력하세요.\n\n' +
-                    '힌트: docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.',
+                    '2. joke 이미지로 만든 컨테이너의 ID 최소 앞 4자리를 입력하세요.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>docker ps -a 명령어로 모든 컨테이너를 확인할 수 있습니다.</li>
+</ul>
+                `,
             },
             {
                 id: 9,
@@ -111,9 +135,12 @@ export class QuizService {
                 content:
                     '실행 중인 컨테이너를 중지해보겠습니다.\n\n' +
                     '1. docker stop 명령어를 사용하여 실행 중인 모든 컨테이너를 중지하세요.\n' +
-                    '2. 컨테이너가 중지되면 상태가 Exited로 변경됩니다.\n\n' +
-                    '힌트: docker stop <컨테이너ID> 형식으로 명령어를 작성하세요.\n' +
-                    '힌트: 컨테이너ID 전부 적을 필요는 없습니다.',
+                    '2. 컨테이너가 중지되면 상태가 Exited로 변경됩니다.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>docker stop <컨테이너ID> 형식으로 명령어를 작성하세요.</li>
+  <li>컨테이너ID 전부 적을 필요는 없습니다.</li>
+</ul>
+                `,
             },
             {
                 id: 10,
@@ -122,9 +149,12 @@ export class QuizService {
                     '더 이상 필요하지 않은 컨테이너를 삭제해봅시다.\n\n' +
                     '1. docker rm 명령어를 사용하여 모든 컨테이너를 삭제하세요.\n' +
                     '2. 컨테이너가 실행 중인 경우 먼저 중지한 후 삭제해야 합니다.\n' +
-                    '3. 삭제 후 docker ps -a로 확인해보세요.\n\n' +
-                    '힌트: docker rm <컨테이너ID> 형식으로 명령어를 작성하세요.\n' +
-                    '힌트: 컨테이너ID 전부 적을 필요는 없습니다.',
+                    '3. 삭제 후 docker ps -a로 확인해보세요.\n',
+                hint: `<ul class="list-disc list-inside">
+  <li>docker rm <컨테이너ID> 형식으로 명령어를 작성하세요.</li>
+  <li>컨테이너ID 전부 적을 필요는 없습니다.</li>
+</ul>
+                `,
             },
         ];
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,7 +57,7 @@ const App = () => {
                         startButtonRef={startButtonRef}
                         setOpenTimerModal={setOpenTimerModal}
                     />
-                    <div className='ml-[17rem] mt-16 flex-row p-5 w-full z-0'>
+                    <div className='ml-[17rem] mt-16 px-12 py-6 w-full h-[calc(100vh-4rem)] z-0 overflow-y-auto'>
                         <Routes>
                             <Route
                                 path='/'

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -64,32 +64,34 @@ const QuizButtons = ({ quizNumber, answer, showAlert }: QuizButtonsProps) => {
     };
 
     return (
-        <section className='flex justify-end gap-6 mb-6'>
-            <button
-                className='text-lg text-white rounded-lg bg-gray-300 hover:bg-gray-400 py-2 px-4'
-                onClick={handlePrevButtonClick}
-            >
-                이전
-            </button>
-            <button
-                className='text-lg text-white rounded-lg bg-sky-400 hover:bg-sky-500 py-2 px-4'
-                onClick={handleNextButtonClick}
-            >
-                다음
-            </button>
-            <button
-                onClick={handleSubmitButtonClick}
-                className='text-xl text-white rounded-lg bg-Moby-Blue hover:bg-blue-800 py-2 px-4'
-            >
-                채점하기
-            </button>
-            <QuizSubmitResultModal
-                openModal={openModal}
-                setOpenModal={setOpenModal}
-                submitResult={submitResult}
-                handleNextButtonClick={handleNextButtonClick}
-            ></QuizSubmitResultModal>
-        </section>
+        <div className='flex justify-end mb-6'>
+            <section className='flex justify-between gap-6 w-72'>
+                <button
+                    className='text-lg text-white rounded-lg bg-gray-300 hover:bg-gray-400 py-2 px-4'
+                    onClick={handlePrevButtonClick}
+                >
+                    이전
+                </button>
+                <button
+                    className='text-lg text-white rounded-lg bg-sky-400 hover:bg-sky-500 py-2 px-4'
+                    onClick={handleNextButtonClick}
+                >
+                    다음
+                </button>
+                <button
+                    onClick={handleSubmitButtonClick}
+                    className='text-xl text-white rounded-lg bg-Moby-Blue hover:bg-blue-800 py-2 px-4'
+                >
+                    채점하기
+                </button>
+                <QuizSubmitResultModal
+                    openModal={openModal}
+                    setOpenModal={setOpenModal}
+                    submitResult={submitResult}
+                    handleNextButtonClick={handleNextButtonClick}
+                ></QuizSubmitResultModal>
+            </section>
+        </div>
     );
 };
 

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -64,22 +64,22 @@ const QuizButtons = ({ quizNumber, answer, showAlert }: QuizButtonsProps) => {
     };
 
     return (
-        <section className='w-[85%] flex justify-end'>
+        <section className='flex justify-end gap-6 mb-6'>
             <button
-                className='text-lg text-white rounded-lg bg-gray-300 hover:bg-gray-400 py-2 px-4 my-4 mx-1'
+                className='text-lg text-white rounded-lg bg-gray-300 hover:bg-gray-400 py-2 px-4'
                 onClick={handlePrevButtonClick}
             >
                 이전
             </button>
             <button
-                className='text-lg text-white rounded-lg bg-sky-400 hover:bg-sky-500 py-2 px-4 m-4'
+                className='text-lg text-white rounded-lg bg-sky-400 hover:bg-sky-500 py-2 px-4'
                 onClick={handleNextButtonClick}
             >
                 다음
             </button>
             <button
                 onClick={handleSubmitButtonClick}
-                className='text-xl text-white rounded-lg bg-Moby-Blue hover:bg-blue-800 py-2 px-4 m-4'
+                className='text-xl text-white rounded-lg bg-Moby-Blue hover:bg-blue-800 py-2 px-4'
             >
                 채점하기
             </button>

--- a/frontend/src/components/quiz/QuizDescription.tsx
+++ b/frontend/src/components/quiz/QuizDescription.tsx
@@ -4,8 +4,8 @@ type QuizDescriptionProps = {
 
 const QuizDescription = ({ content }: QuizDescriptionProps) => {
     return (
-        <div className='w-[33%] border rounded-lg border-gray-300 my-4 ml-4 mr-1 pl-4'>
-            <h2 className='font-semibold text-2xl text-Dark-Blue pt-4 pb-2'>문제</h2>
+        <div className='w-[45%] border rounded-lg border-gray-300 p-4'>
+            <h2 className='font-semibold text-2xl text-Dark-Blue py-2'>문제</h2>
             <p className='font-medium text-lg text-gray-800 whitespace-pre-wrap'>{content}</p>
         </div>
     );

--- a/frontend/src/components/quiz/QuizDescription.tsx
+++ b/frontend/src/components/quiz/QuizDescription.tsx
@@ -1,12 +1,33 @@
+import { Accordion } from 'flowbite-react';
+import { CircleHelp } from 'lucide-react';
+
 type QuizDescriptionProps = {
-    content: string | undefined;
+    content: string;
+    hint?: string;
 };
 
-const QuizDescription = ({ content }: QuizDescriptionProps) => {
+const QuizDescription = ({ content, hint = '' }: QuizDescriptionProps) => {
     return (
         <div className='w-[45%] border rounded-lg border-gray-300 p-4'>
             <h2 className='font-semibold text-2xl text-Dark-Blue py-2'>문제</h2>
             <p className='font-medium text-lg text-gray-800 whitespace-pre-wrap'>{content}</p>
+            {hint && (
+                <Accordion className='rounded-none border-x-0 mt-5' collapseAll>
+                    <Accordion.Panel className='rounded-none'>
+                        <Accordion.Title className='focus:ring-0 p-3 first:rounded-none last:rounded-none'>
+                            <span className='inline-flex items-center gap-1'>
+                                <CircleHelp className='w-5 h-5' /> <span>Hint</span>
+                            </span>
+                        </Accordion.Title>
+                        <Accordion.Content className='p-3 first:rounded-none last:rounded-none'>
+                            <div
+                                className='text-gray-500 dark:text-gray-400'
+                                dangerouslySetInnerHTML={{ __html: hint }}
+                            />
+                        </Accordion.Content>
+                    </Accordion.Panel>
+                </Accordion>
+            )}
         </div>
     );
 };

--- a/frontend/src/components/quiz/QuizInputBox.tsx
+++ b/frontend/src/components/quiz/QuizInputBox.tsx
@@ -8,9 +8,9 @@ const QuizInputBox = ({ answer, setAnswer }: QuizInputBoxProps) => {
         setAnswer(e.target.value);
     };
     return (
-        <div className='w-[85%] flex justify-end'>
+        <div className='flex justify-end'>
             <input
-                className='w-60 h-8 rounded-lg border border-gray-300 mt-4 outline-none ml-1'
+                className='h-9 rounded-lg border border-gray-300 outline-none bg-gray-50'
                 type='text'
                 onChange={handleChange}
                 value={answer}

--- a/frontend/src/components/quiz/QuizInputBox.tsx
+++ b/frontend/src/components/quiz/QuizInputBox.tsx
@@ -10,7 +10,7 @@ const QuizInputBox = ({ answer, setAnswer }: QuizInputBoxProps) => {
     return (
         <div className='flex justify-end'>
             <input
-                className='h-9 rounded-lg border border-gray-300 outline-none bg-gray-50'
+                className='h-9 w-72 rounded-lg border border-gray-300 outline-none bg-gray-50'
                 type='text'
                 onChange={handleChange}
                 value={answer}

--- a/frontend/src/components/quiz/QuizNodes.tsx
+++ b/frontend/src/components/quiz/QuizNodes.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export const QuizNodes = ({ showAlert, quizId }: Props) => {
-    const { title, content, isPending: pending, isError: error } = useQuizData(quizId);
+    const { title, content, hint, isPending: pending, isError: error } = useQuizData(quizId);
     const quizNumber = +quizId;
     const customQuiz = CUSTOM_QUIZZES.includes(quizNumber);
 
@@ -31,7 +31,7 @@ export const QuizNodes = ({ showAlert, quizId }: Props) => {
 
     return {
         head: <h1 className='font-bold text-3xl text-Dark-Blue pb-3 h-12'>{title}</h1>,
-        description: <QuizDescription content={content} />,
+        description: <QuizDescription content={content} hint={hint} />,
         submit: (
             <QuizSubmitArea quizNumber={quizNumber} showInput={customQuiz} showAlert={showAlert} />
         ),

--- a/frontend/src/components/quiz/QuizNodes.tsx
+++ b/frontend/src/components/quiz/QuizNodes.tsx
@@ -15,7 +15,7 @@ export const QuizNodes = ({ showAlert, quizId }: Props) => {
 
     if (pending) {
         return {
-            head: <h1 className='font-bold text-3xl text-Dark-Blue mb-3'>로딩 중...</h1>,
+            head: <h1 className='font-bold text-3xl text-Dark-Blue pb-3 h-12'>로딩 중...</h1>,
             description: <QuizDescription content={'퀴즈를 불러오는 중입니다...'} />,
             submit: null,
         };
@@ -23,14 +23,14 @@ export const QuizNodes = ({ showAlert, quizId }: Props) => {
 
     if (error) {
         return {
-            head: <h1 className='font-bold text-3xl text-Dark-Blue mb-3'>오류 발생</h1>,
+            head: <h1 className='font-bold text-3xl text-Dark-Blue pb-3 h-12'>오류 발생</h1>,
             description: <QuizDescription content={'퀴즈를 불러오는데 실패했습니다.'} />,
             submit: null,
         };
     }
 
     return {
-        head: <h1 className='font-bold text-3xl text-Dark-Blue mb-3'>{title}</h1>,
+        head: <h1 className='font-bold text-3xl text-Dark-Blue pb-3 h-12'>{title}</h1>,
         description: <QuizDescription content={content} />,
         submit: (
             <QuizSubmitArea quizNumber={quizNumber} showInput={customQuiz} showAlert={showAlert} />

--- a/frontend/src/components/quiz/QuizPage.tsx
+++ b/frontend/src/components/quiz/QuizPage.tsx
@@ -15,19 +15,23 @@ type QuizPageProps = {
 
 export const QuizContent = ({ showAlert, quizId, eventSourceRef }: QuizContentProps) => {
     const quizNodes = QuizNodes({ showAlert, quizId });
-    
+
     const visualNodes = VisualizationNodes({ eventSourceRef, showAlert });
 
     return (
-        <div className='w-[calc(100vw-17rem)]'>
+        <>
             {quizNodes.head}
-            <section className='flex h-1/2'>
-                {quizNodes.description}
-                {visualNodes.visualization}
-            </section>
-            {visualNodes.terminal}
-            {quizNodes.submit}
-        </div>
+            <div className='flex flex-col gap-3 h-[calc(100vh-10rem)] justify-between'>
+                <div className='flex gap-3 flex-1'>
+                    {quizNodes.description}
+                    {visualNodes.visualization}
+                </div>
+                <div className='flex flex-col gap-3 flex-1'>
+                    {visualNodes.terminal}
+                    {quizNodes.submit}
+                </div>
+            </div>
+        </>
     );
 };
 

--- a/frontend/src/components/quiz/QuizPage.tsx
+++ b/frontend/src/components/quiz/QuizPage.tsx
@@ -26,7 +26,7 @@ export const QuizContent = ({ showAlert, quizId, eventSourceRef }: QuizContentPr
                     {quizNodes.description}
                     {visualNodes.visualization}
                 </div>
-                <div className='flex flex-col gap-3 flex-1'>
+                <div className='flex flex-col 2xl:flex-row gap-3 2xl:gap-5 flex-1'>
                     {visualNodes.terminal}
                     {quizNodes.submit}
                 </div>

--- a/frontend/src/components/quiz/QuizSubmitArea.tsx
+++ b/frontend/src/components/quiz/QuizSubmitArea.tsx
@@ -12,9 +12,9 @@ export const QuizSubmitArea = ({ quizNumber, showInput, showAlert }: QuizSubmitA
     const [answer, setAnswer] = useState('');
 
     return (
-        <>
+        <div className='flex flex-col gap-3 flex-none'>
             {showInput && <QuizInputBox answer={answer} setAnswer={setAnswer} />}
             <QuizButtons quizNumber={quizNumber} answer={answer} showAlert={showAlert} />
-        </>
+        </div>
     );
 };

--- a/frontend/src/components/quiz/XTerminal.tsx
+++ b/frontend/src/components/quiz/XTerminal.tsx
@@ -55,8 +55,8 @@ const XTerminal = ({ updateVisualizationData, hostStatus, showAlert }: XTerminal
     }, [hostStatus]);
 
     return (
-        <div className='h-[30%] w-[83.5%] border rounded-lg border-black bg-black ml-4'>
-            <div ref={terminalRef} className='h-full w-full p-2 custom-terminal' />
+        <div className='border rounded-lg border-black bg-black flex-1'>
+            <div ref={terminalRef} className='p-2 custom-terminal h-full' />
         </div>
     );
 };

--- a/frontend/src/components/staticpages/LandingPage.tsx
+++ b/frontend/src/components/staticpages/LandingPage.tsx
@@ -46,7 +46,7 @@ const Banner = ({
 
     return (
         <div className='bg-neutral-100 rounded-lg'>
-            <div className='container mx-auto px-4 py-16'>
+            <div className='container mx-auto px-10 py-16'>
                 <div className='max-w-3xl'>
                     <h1 className='text-4xl font-bold mb-6'>Docker를 쉽고 재미있게 배워보세요!</h1>
                     <p className='text-xl mb-8'>

--- a/frontend/src/components/visualization/DockerVisualization.tsx
+++ b/frontend/src/components/visualization/DockerVisualization.tsx
@@ -35,7 +35,7 @@ const DockerVisualization = ({
 
     return (
         <div
-            className='grid w-[50%] border rounded-lg border-gray-300 my-4 ml-1'
+            className='grid w-[55%] border rounded-lg border-gray-300'
             style={{
                 gridTemplateColumns: '1fr 0.5fr 1fr 0.5fr 1fr 0.5fr 1fr',
                 gridTemplateRows: 'repeat(5, 1fr)',

--- a/frontend/src/hooks/useQuizData.ts
+++ b/frontend/src/hooks/useQuizData.ts
@@ -20,6 +20,7 @@ export const useQuizData = (quizId: string) => {
         id: quizData?.id ?? 0,
         title: quizData?.title ?? '',
         content: quizData?.content ?? '',
+        hint: quizData?.hint ?? '',
         isPending,
         isError,
     };

--- a/frontend/src/types/quiz.ts
+++ b/frontend/src/types/quiz.ts
@@ -2,6 +2,7 @@ export type Quiz = {
     id: number;
     title: string;
     content: string | undefined;
+    hint: string | undefined;
 };
 
 export type SubmitStatus = 'SUCCESS' | 'FAIL';

--- a/frontend/src/utils/terminalUtils.ts
+++ b/frontend/src/utils/terminalUtils.ts
@@ -14,12 +14,12 @@ export function createTerminal(container: HTMLElement): Terminal {
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.open(container);
-    fitAddon.fit();
 
     const handleResize = () => {
-        fitAddon.fit();
         terminal.resize(terminal.cols, 20);
+        fitAddon.fit();
     };
+    handleResize();
 
     window.addEventListener('resize', handleResize);
 


### PR DESCRIPTION
## 작업 개요

closes #312 
closes #315 
closes #319 

## 작업 상세 내용

- 숨겨진 힌트를 드러내는 버튼 추가
  - 힌트 항목을 문제 항목과 따로 드러내기 위해 DB 테이블에 hint 컬럼을 추가, 문제 조회 API 응답 시 content와 hint가 분리되어 날아갑니다.
  - 힌트 항목은 HTML tag를 포함하며, 이를 위해 dangerouslySetInnerHTML를 사용했습니다
- input 창과 버튼 정렬
  - 페이지 전체를 사용하게 해서 오른쪽 끝을 맞췄습니다
- 이미지 조회하기 문제같은 경우, 우측 하단에 위치한 입력창에 입력해야 한다는 안내 문구를 추가했습니다
- 명령창의 세로 길이를 최대한 활용할 수 있게 늘렸습니다. 명령창의 세로 길이가 고정되어 있으면 `ctrl`+`-`를 여러번 했을 때 명령창이 화면에 맞게 늘어나지 않아서, 이를 해결하고 싶었습니다.
  - 명령창을 담는 wrapper element에 h-full을 주어 가용한 높이를 다 사용하여 터미널 공간을 확보했습니다.
  - 피드백 부탁드립니다.. 별로면 삭제하겠습니다
- 넓은 디스플레이를 사용하면 터미널이 불필요하게 가로로 길어지는 문제가 있어, 이를 반응형으로 해결하고자 했습니다.
  - 터미널 resize가 원활이 되지 않는 상황입니다.
  - 마지막 커밋의 이전 커밋으로 반응형이 적용되지 않은 상태를 확인하실 수 있습니다.
