### PR TITLE
xterm 명령창 에러문 개선, 복붙 기능 구현

### DIFF
--- a/backend/src/common/exception/filters.ts
+++ b/backend/src/common/exception/filters.ts
@@ -42,6 +42,7 @@ export class LastExceptionFilter implements ExceptionFilter {
             statusCode: httpStatus,
             timestamp: new Date().toISOString(),
             path: httpAdapter.getRequestUrl(ctx.getRequest()),
+            message: exception instanceof HttpException ? exception.message : undefined,
         };
 
         if (this.constructor.name === 'LastExceptionFilter') {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.61.5",
     "@types/aos": "^3.0.7",
+    "@xterm/addon-clipboard": "^0.1.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "aos": "^2.3.4",

--- a/frontend/src/api/quiz.ts
+++ b/frontend/src/api/quiz.ts
@@ -104,7 +104,7 @@ export const requestHostStatus = async (navigate: NavigateFunction) => {
 export const requestCommandResult = async (
     command: string,
     term: Terminal,
-    customErrorCallback: (term: Terminal, statusCode: number) => void
+    customErrorCallback: (term: Terminal, statusCode: number, errorMessage: string) => void
 ) => {
     const loadingTerminal = new LoadingTerminal(term);
 
@@ -117,7 +117,7 @@ export const requestCommandResult = async (
         loadingTerminal.spinnerStop();
         if (axios.isAxiosError(error)) {
             const statusCode = error.response?.status || 500;
-            customErrorCallback(term, statusCode);
+            customErrorCallback(term, statusCode, error.response?.data.message);
         } else {
             console.error('unknown error');
         }

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -8,6 +8,7 @@ import {
 } from '../utils/terminalUtils';
 import { ENTER_KEY, BACKSPACE_KEY } from '../constant/xterm';
 import { HttpStatusCode } from 'axios';
+import { BrowserClipboardProvider, ClipboardSelectionType } from '@xterm/addon-clipboard';
 
 export function useTerminal(
     updateVisualizationData: (command: string) => Promise<void>,
@@ -34,10 +35,33 @@ export function useTerminal(
         term.write(`\x1b[91m${message}\x1b[0m\r\n`);
     };
 
-    const handleKeyInput = async (term: Terminal, key: string) => {
+    const handleKeyInput = async (
+        term: Terminal,
+        event: { key: string; domEvent: KeyboardEvent },
+        clipboardProvider: BrowserClipboardProvider
+    ) => {
         if (blockingRef.current || tooManyRequestRef.current) return;
 
-        switch (key) {
+        if ((event.domEvent.metaKey || event.domEvent.ctrlKey) && event.domEvent.key === 'c') {
+            const selection = term.getSelection();
+            if (selection) {
+                await clipboardProvider.writeText('c' as ClipboardSelectionType, selection);
+            }
+            return;
+        }
+
+        if ((event.domEvent.metaKey || event.domEvent.ctrlKey) && event.domEvent.key === 'v') {
+            try {
+                const text = await clipboardProvider.readText('c' as ClipboardSelectionType);
+                term.write(text);
+                currentLineRef.current += text;
+            } catch (err) {
+                console.error('Failed to paste:', err);
+            }
+            return;
+        }
+
+        switch (event.key) {
             case ENTER_KEY: {
                 blockingRef.current = true;
                 await handleEnter(
@@ -57,8 +81,8 @@ export function useTerminal(
             }
 
             default: {
-                if (!isPrintableKey(key)) return;
-                currentLineRef.current = handleDefaultKey(term, key, currentLineRef.current);
+                if (!isPrintableKey(event.key)) return;
+                currentLineRef.current = handleDefaultKey(term, event.key, currentLineRef.current);
                 break;
             }
         }

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -17,11 +17,11 @@ export function useTerminal(
     const blockingRef = useRef<boolean>(false);
     const tooManyRequestRef = useRef<boolean>(false);
 
-    const handleCommandError = (term: Terminal, statusCode: number) => {
+    const handleCommandError = (term: Terminal, statusCode: number, errorMessage: string) => {
         if (!term) return;
         if (statusCode === HttpStatusCode.TooManyRequests) {
             showAlert('잠시후 다시 시도해주세요');
-            
+
             tooManyRequestRef.current = true;
             setTimeout(() => {
                 tooManyRequestRef.current = false;
@@ -29,7 +29,9 @@ export function useTerminal(
 
             return;
         }
-        term.write('\x1b[91m허용되지 않은 명령어 입니다.\x1b[0m\r\n');
+
+        const message = errorMessage || '허용되지 않은 명령어 입니다.';
+        term.write(`\x1b[91m${message}\x1b[0m\r\n`);
     };
 
     const handleKeyInput = async (term: Terminal, key: string) => {

--- a/frontend/src/utils/terminalUtils.ts
+++ b/frontend/src/utils/terminalUtils.ts
@@ -1,8 +1,12 @@
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { BrowserClipboardProvider, ClipboardAddon } from '@xterm/addon-clipboard';
 import { requestCommandResult } from '../api/quiz';
 
-export function createTerminal(container: HTMLElement): Terminal {
+export function createTerminal(container: HTMLElement): {
+    terminal: Terminal;
+    clipboardProvider: BrowserClipboardProvider;
+} {
     const terminal = new Terminal({
         cursorBlink: true,
         fontFamily: '"Noto Sans Mono", "Noto Sans KR", courier-new, courier, monospace',
@@ -11,8 +15,13 @@ export function createTerminal(container: HTMLElement): Terminal {
         fontWeight: '300',
     });
 
+    const clipboardProvider = new BrowserClipboardProvider();
+    const clipboardAddon = new ClipboardAddon(clipboardProvider);
     const fitAddon = new FitAddon();
+
+    terminal.loadAddon(clipboardAddon);
     terminal.loadAddon(fitAddon);
+
     terminal.open(container);
     fitAddon.fit();
 
@@ -26,10 +35,11 @@ export function createTerminal(container: HTMLElement): Terminal {
     const originalDispose = terminal.dispose.bind(terminal);
     terminal.dispose = () => {
         window.removeEventListener('resize', handleResize);
+        clipboardAddon.dispose();
         originalDispose();
     };
 
-    return terminal;
+    return { terminal, clipboardProvider };
 }
 
 const handleClear = (term: Terminal) => {
@@ -48,7 +58,7 @@ export const handleBackspace = (term: Terminal, currentLine: string) => {
 export const handleEnter = async (
     term: Terminal,
     command: string,
-    handleCommandError: (term: Terminal, statusCode: number) => void,
+    handleCommandError: (term: Terminal, statusCode: number, errorMessage: string) => void,
     updateVisualization: (command: string) => Promise<void>
 ) => {
     if (!command) {


### PR DESCRIPTION
## 작업 개요
- resolve #293 
- resolve #317 

## 작업 상세 내용
### xterm 명령창 에러문 개선
- 허용되지 않은 명령어 입니다 고정 메시지를 response의 message로 수정
- detach 옵션과 함께 실행되어야 하는 커스텀 이미지의 경우
- joke 이미지는 detach 옵션(-d 또는 --detach)과 함께 실행해야 합니다! 이렇게 명령창으로 표시
![image](https://github.com/user-attachments/assets/bbeee607-3cf3-47c3-ad93-b6c6426a5f33)
### 복붙 기능 구현
- xterm의 clipboardaddon을 사용해서 구현했습니다.
####  await clipboardProvider.readText('c' as ClipboardSelectionType); 타입 단언한 이유 
- `const text = await clipboardProvider.readText('c' as ClipboardSelectionType);` 이런식으로 타입을 단언 한 부분이 있습니다
- readText(selection: ClipboardSelectionType): Promise<string>;가 ClipboardSelectionType을 요구하고 
- ClipboardSelectionType은 const enum으로 되어 있습니다.
```js
 export const enum ClipboardSelectionType {
    SYSTEM = 'c',
    PRIMARY = 'p',
  }
```
- 또한 번들러 모듈에서 isolatedModules: true로 되어 있습니다.
```
    /* Bundler mode */
    "moduleResolution": "Bundler",
    "allowImportingTsExtensions": true,
    "isolatedModules": true,
...
```
- const enum과 isolatedModules: true을 같이 사용하지 못합니다.
- isolatedModules를 false인 경우 ClipboardSelectionType이 undefined가 됩니다.
- const enum을 enum으로 바꾸는것은 외부 라이브러리이기 때문에 불가능합니다.
- 그래서 타입 단언을 사용했습니다.

## 문제 상황
### 클립보드 권한 요청 문제
- 복사하기 같은 경우 잘 되는데 붙여넣기 할때 권한 요청하는 문제가 있습니다.
- 권한 요청을 하는 경우가 명시적인 사용자의 상호작용이 없거나 http환경 때문 일수도 있다고 하네요
- 권한 요청없이 xterm에 붙여넣기를 할 수 있도록 보완하겠습니다.