### PR TITLE
퀴즈 페이지 간 이동 시에도 터미널이 clear되는 현상 해결

### DIFF
--- a/backend/src/sandbox/sandbox.service.ts
+++ b/backend/src/sandbox/sandbox.service.ts
@@ -62,7 +62,7 @@ export class SandboxService {
         return containerData.reduce<Array<Container>>((containerReducer, container) => {
             containerReducer.push({
                 id: container.Id,
-                name: container.Names[0],
+                name: container.Names[0].split('/')[1],
                 image: container.Image,
                 status: container.State,
             });

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -41,7 +41,12 @@ const QuizButtons = ({
         setOpenModal(true);
 
         if (submitResponse.quizResult === 'SUCCESS') {
-            setUserLevel(quizNumber + 1);
+            setUserLevel((prev) => {
+                if (prev < quizNumber + 1) {
+                    return quizNumber + 1;
+                }
+                return prev;
+            });
 
             if (1 <= quizNumber && quizNumber <= 3) {
                 updateSidebarState(dockerImageStates, quizNumber);

--- a/frontend/src/components/quiz/QuizNodes.tsx
+++ b/frontend/src/components/quiz/QuizNodes.tsx
@@ -9,9 +9,16 @@ type Props = {
     quizId: string;
     sidebarStates: SidebarElementsProps;
     setSidebarStates: React.Dispatch<React.SetStateAction<SidebarElementsProps>>;
+    setUserLevel: React.Dispatch<React.SetStateAction<number>>;
 };
 
-export const QuizNodes = ({ showAlert, quizId, sidebarStates, setSidebarStates }: Props) => {
+export const QuizNodes = ({
+    showAlert,
+    quizId,
+    sidebarStates,
+    setSidebarStates,
+    setUserLevel,
+}: Props) => {
     const { title, content, hint, isPending: pending, isError: error } = useQuizData(quizId);
     const quizNumber = +quizId;
     const customQuiz = CUSTOM_QUIZZES.includes(quizNumber);
@@ -42,6 +49,7 @@ export const QuizNodes = ({ showAlert, quizId, sidebarStates, setSidebarStates }
                 showAlert={showAlert}
                 sidebarStates={sidebarStates}
                 setSidebarStates={setSidebarStates}
+                setUserLevel={setUserLevel}
             />
         ),
     };

--- a/frontend/src/components/quiz/QuizPage.tsx
+++ b/frontend/src/components/quiz/QuizPage.tsx
@@ -8,6 +8,7 @@ type QuizContentProps = {
     quizId: string;
     sidebarStates: SidebarElementsProps;
     setSidebarStates: React.Dispatch<React.SetStateAction<SidebarElementsProps>>;
+    setUserLevel: React.Dispatch<React.SetStateAction<number>>;
 };
 
 type QuizPageProps = {
@@ -21,12 +22,14 @@ export const QuizContent = ({
     quizId,
     sidebarStates,
     setSidebarStates,
+    setUserLevel,
 }: QuizContentProps) => {
     const quizNodes = QuizNodes({
         showAlert,
         quizId,
         sidebarStates,
         setSidebarStates,
+        setUserLevel,
     });
 
     const visualNodes = VisualizationNodes({ showAlert });
@@ -51,12 +54,13 @@ export const QuizContent = ({
 export const QuizPage = ({ showAlert, sidebarStates, setSidebarStates }: QuizPageProps) => {
     return (
         <QuizPageWrapper showAlert={showAlert}>
-            {(quizId) => (
+            {(quizId, setUserLevel) => (
                 <QuizContent
                     showAlert={showAlert}
                     quizId={quizId}
                     sidebarStates={sidebarStates}
                     setSidebarStates={setSidebarStates}
+                    setUserLevel={setUserLevel}
                 />
             )}
         </QuizPageWrapper>

--- a/frontend/src/components/quiz/QuizPageWrapper.tsx
+++ b/frontend/src/components/quiz/QuizPageWrapper.tsx
@@ -4,19 +4,17 @@ import { requestQuizAccessability } from '../../api/quiz';
 import { HttpStatusCode } from 'axios';
 
 type QuizPageWrapperProps = {
-    children: (quizId: string) => React.ReactNode;
+    children: (
+        quizId: string,
+        setUserLevel: React.Dispatch<React.SetStateAction<number>>
+    ) => React.ReactNode;
     showAlert: (message: string) => void;
-};
-
-type userValidationState = {
-    start: boolean;
-    level: number;
 };
 
 export const QuizPageWrapper = ({ children, showAlert }: QuizPageWrapperProps) => {
     const { quizId } = useParams<{ quizId: string }>();
     const quizNumber = Number(quizId);
-    const [validated, setvalidated] = useState<userValidationState>({ start: false, level: 0 });
+    const [userLevel, setUserLevel] = useState<number>(0);
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -42,17 +40,17 @@ export const QuizPageWrapper = ({ children, showAlert }: QuizPageWrapperProps) =
                 return;
             }
 
-            if (validated.level < quizNumber) {
-                setvalidated({ start: true, level: quizNumber });
+            if (userLevel < quizNumber) {
+                setUserLevel(quizNumber);
             }
         };
 
         validateQuiz();
     }, [quizNumber, navigate, showAlert]);
 
-    if (validated.start === false || validated.level < quizNumber) {
+    if (userLevel < quizNumber) {
         return null;
     }
 
-    return <>{children(quizId as string)}</>;
+    return <>{children(quizId as string, setUserLevel)}</>;
 };

--- a/frontend/src/components/quiz/QuizSubmitArea.tsx
+++ b/frontend/src/components/quiz/QuizSubmitArea.tsx
@@ -9,6 +9,7 @@ type QuizSubmitAreaProps = {
     showAlert: (message: string) => void;
     sidebarStates: SidebarElementsProps;
     setSidebarStates: React.Dispatch<React.SetStateAction<SidebarElementsProps>>;
+    setUserLevel: React.Dispatch<React.SetStateAction<number>>;
 };
 
 export const QuizSubmitArea = ({
@@ -17,6 +18,7 @@ export const QuizSubmitArea = ({
     showAlert,
     sidebarStates,
     setSidebarStates,
+    setUserLevel,
 }: QuizSubmitAreaProps) => {
     const [answer, setAnswer] = useState('');
 
@@ -29,6 +31,7 @@ export const QuizSubmitArea = ({
                 showAlert={showAlert}
                 sidebarStates={sidebarStates}
                 setSidebarStates={setSidebarStates}
+                setUserLevel={setUserLevel}
             />
         </div>
     );


### PR DESCRIPTION
## 작업 개요

- 퀴즈 페이지 이동시 터미널이 clear되는 현상 해결
- sidebar 체크 표시 로직 수정

## 작업 상세 내용

- [x] 퀴즈 페이지 이동시 터미널이 clear되는 현상 해결
  - [x] validated 상태 변수를 userLevel 상태 변수로 변경
  - [x] setUserLevel 함수를 props로 QuizButtons에 전달해서 퀴즈를 성공하는 경우 userLevel을 업데이트
- [x] sidebar 체크 표시 로직 수정
  - [x] 체크 표시 업데이트를 모달창에서 "다음 퀴즈 풀기"를 누르는 시점이 아닌, 퀴즈를 성공하는 시점으로 변경
- [x] 컨테이너 이름 앞에 붙는 `/` 제거

## 결과 화면

![refactor-terminal-clear](https://github.com/user-attachments/assets/51b45105-b557-40b6-95bf-01c9a112a56f)

