### PR TITLE
ImageId로부터 docker run 시 색상 입혀지지 않는 버그 해결

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,9 +16,9 @@ import { useAlert } from './hooks/useAlert';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useSidebar } from './hooks/useSidebar';
 import { TimerModal } from './components/modals/TimerModal';
+import { handleBeforeUnload } from './handlers/handler';
 
 const queryClient = new QueryClient();
-
 const App = () => {
     const { openAlert, message, showAlert } = useAlert();
     const { sidebarStates, setSidebarStates } = useSidebar();
@@ -30,10 +30,6 @@ const App = () => {
         AOS.init({
             duration: 500,
         });
-        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-            e.preventDefault();
-            return '';
-        };
 
         window.addEventListener('beforeunload', handleBeforeUnload);
 

--- a/frontend/src/components/StopButton.tsx
+++ b/frontend/src/components/StopButton.tsx
@@ -1,5 +1,6 @@
 import { requestReleaseSession } from '../api/quiz';
 import { useNavigate } from 'react-router-dom';
+import { handleBeforeUnload } from '../handlers/handler';
 
 type StopButtonProps = {
     setMaxAge: React.Dispatch<React.SetStateAction<number>>;
@@ -9,6 +10,7 @@ const StopButton = ({ setMaxAge }: StopButtonProps) => {
     const navigate = useNavigate();
 
     const handleStopButtonClick = async () => {
+        window.removeEventListener('beforeunload', handleBeforeUnload);
         await requestReleaseSession(navigate);
         window.sessionStorage.removeItem('endDate');
         setMaxAge(0);

--- a/frontend/src/components/popover/ContainerPopover.tsx
+++ b/frontend/src/components/popover/ContainerPopover.tsx
@@ -20,9 +20,9 @@ const ContainerPopover = ({ container }: ContainerPopoverProps) => {
             </li>
             <li className='mb-2'>
                 <div className='text-xs font-semibold text-gray-500 mb-1'>Name</div>
-                <Tooltip trigger='hover' content={name}>
+                <Tooltip trigger='hover' content={name.slice(1)}>
                     <div className='w-[200px] truncate overflow-hidden text-ellipsis whitespace-nowrap text-sm p-2 bg-white border border-gray-300 rounded-md'>
-                        {name}
+                        {name.slice(1)}
                     </div>
                 </Tooltip>
             </li>

--- a/frontend/src/components/popover/ContainerPopover.tsx
+++ b/frontend/src/components/popover/ContainerPopover.tsx
@@ -20,9 +20,9 @@ const ContainerPopover = ({ container }: ContainerPopoverProps) => {
             </li>
             <li className='mb-2'>
                 <div className='text-xs font-semibold text-gray-500 mb-1'>Name</div>
-                <Tooltip trigger='hover' content={name.slice(1)}>
+                <Tooltip trigger='hover' content={name}>
                     <div className='w-[200px] truncate overflow-hidden text-ellipsis whitespace-nowrap text-sm p-2 bg-white border border-gray-300 rounded-md'>
-                        {name.slice(1)}
+                        {name}
                     </div>
                 </Tooltip>
             </li>

--- a/frontend/src/components/popover/ImagePopover.tsx
+++ b/frontend/src/components/popover/ImagePopover.tsx
@@ -1,5 +1,6 @@
 import { Image } from '../../types/visualization';
 import { Tooltip } from 'flowbite-react';
+import { IMAGEID_PREFIX_INDEX } from '../../constant/visualization';
 
 type ImagePopoverProps = {
     image: Image;
@@ -7,7 +8,7 @@ type ImagePopoverProps = {
 
 const ImagePopover = ({ image }: ImagePopoverProps) => {
     const { id, name } = image;
-    const filteredId = id.slice(7);
+    const filteredId = id.slice(IMAGEID_PREFIX_INDEX);
 
     return (
         <ul className='p-2 bg-gray-50 rounded-lg shadow-md border border-gray-200'>

--- a/frontend/src/components/visualization/ContainerNode.tsx
+++ b/frontend/src/components/visualization/ContainerNode.tsx
@@ -69,7 +69,7 @@ const ContainerNode = ({
                                         className={`absolute -top-1 -right-1 inline-flex rounded-full h-2 w-2 ${STATUS_COLORS[element.status]}`}
                                     ></span>
 
-                                    <div className='truncate'>{element.name.slice(1)}</div>
+                                    <div className='truncate'>{element.name}</div>
                                 </>
                             ) : (
                                 <div className='truncate'>{element.name}</div>

--- a/frontend/src/components/visualization/ContainerNode.tsx
+++ b/frontend/src/components/visualization/ContainerNode.tsx
@@ -5,8 +5,8 @@ import {
     Container,
 } from '../../types/visualization';
 import { Popover } from 'flowbite-react';
-import ContainerToolTip from '../popover/ContainerPopover';
-import ImageToolTip from '../popover/ImagePopover';
+import ContainerPopover from '../popover/ContainerPopover';
+import ImagePopover from '../popover/ImagePopover';
 
 const STATUS_COLORS = {
     [DOCKER_CONTAINER_STATUS.EXITED]: 'bg-Stopped-Status-Color',
@@ -47,9 +47,9 @@ const ContainerNode = ({
                         trigger='hover'
                         content={
                             isContainer(element) ? (
-                                <ContainerToolTip container={element} />
+                                <ContainerPopover container={element} />
                             ) : (
-                                <ImageToolTip image={element} />
+                                <ImagePopover image={element} />
                             )
                         }
                         key={element.id}
@@ -60,7 +60,7 @@ const ContainerNode = ({
                                 borderColor: element.color,
                             }}
                         >
-                            {isContainer(element) && (
+                            {isContainer(element) ? (
                                 <>
                                     <span
                                         className={`absolute -top-1 -right-1  inline-flex h-2 w-2 rounded-full ${STATUS_COLORS[element.status]} opacity-75 animate-ping`}
@@ -68,9 +68,12 @@ const ContainerNode = ({
                                     <span
                                         className={`absolute -top-1 -right-1 inline-flex rounded-full h-2 w-2 ${STATUS_COLORS[element.status]}`}
                                     ></span>
+
+                                    <div className='truncate'>{element.name.slice(1)}</div>
                                 </>
+                            ) : (
+                                <div className='truncate'>{element.name}</div>
                             )}
-                            <div className='truncate'>{element.name}</div>
                         </div>
                     </Popover>
                 ))}

--- a/frontend/src/constant/visualization.ts
+++ b/frontend/src/constant/visualization.ts
@@ -1,3 +1,4 @@
 export const COLORS = ['#000000', '#FFC107', '#4CAF50', '#2196F3', '#673AB7', '#E91E63'];
 export const STATE_CHANGE_COMMAND_REGEX =
     /^docker\s+(run|create|start|stop|pull|rmi|rm|restart|pause|unpause|rename|attach|tag|build|load|commit|kill)(\s|$)/;
+export const IMAGEID_PREFIX_INDEX = 7;

--- a/frontend/src/handlers/handler.ts
+++ b/frontend/src/handlers/handler.ts
@@ -1,0 +1,4 @@
+export const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+    e.preventDefault();
+    return '';
+};

--- a/frontend/src/utils/visualizationUtils.ts
+++ b/frontend/src/utils/visualizationUtils.ts
@@ -1,6 +1,7 @@
 import { Visualization } from '../types/visualization';
 import { COLORS } from '../constant/visualization';
 import { DOCKER_OPERATIONS } from '../types/visualization';
+import { IMAGEID_PREFIX_INDEX } from '../constant/visualization';
 
 export const setColorToElements = (prevElements: Visualization, newElements: Visualization) => {
     const initImages = updateImageColors(prevElements, newElements);
@@ -50,7 +51,10 @@ export const updateContainerColors = (prevElements: Visualization, newElements: 
 
 const compareImageId = (imageId: string, containerImage: string) => {
     const containerImageLen = containerImage.length;
-    return imageId.slice(7, 7 + containerImageLen) === containerImage;
+    return (
+        imageId.slice(IMAGEID_PREFIX_INDEX, IMAGEID_PREFIX_INDEX + containerImageLen) ===
+        containerImage
+    );
 };
 
 const isChangedContainerStatus = (prevElements: Visualization, newElements: Visualization) => {

--- a/frontend/src/utils/visualizationUtils.ts
+++ b/frontend/src/utils/visualizationUtils.ts
@@ -39,13 +39,18 @@ export const updateContainerColors = (prevElements: Visualization, newElements: 
     const { containers } = newElements;
     return containers.map((container) => {
         const image = coloredImages.find((image) => {
-            return image.name === container.image;
+            return compareImageId(image.id, container.image) || image.name === container.image;
         });
         return {
             ...container,
             color: image?.color,
         };
     });
+};
+
+const compareImageId = (imageId: string, containerImage: string) => {
+    const containerImageLen = containerImage.length;
+    return imageId.slice(7, 7 + containerImageLen) === containerImage;
 };
 
 const isChangedContainerStatus = (prevElements: Visualization, newElements: Visualization) => {


### PR DESCRIPTION
## 작업 상세 내용

### ImageID로부터 docker run 을 통해 실행 시 색상 문제

살펴보니 ImageID로부터 생성된 컨테이너의 image는 입력된 ImageID로 설정됩니다. 따라서, 생성된 Container의 Image에 대한 데이터를 Image의 name만 비교하는 것이 아니라, Image의 ID와도 비교를 하여 색상을 입힐 필요가 있었습니다.

### 학습 종료 시 Aler창 문제

학습 종료버튼을 누르면 새로고침 하시겠습니까? 라는 Alert창을 띄우고 해당 창에서 취소를 눌러도 사용자의 모든 작업이 사라지고 새로고침 되는 문제가 있었습니다.

이 문제를 해결하기 위해서 학습 종료 버튼을 누르면, beforeunload이벤트를 일시적으로 remove하도록 하여 해결하였습니다.

한 가지 아쉬운 점은 학습 종료버튼을 사용자가 실수로 누른다면, 모든 작업은 다 날아갈 것입니다. 따라서, 추후에 Modal을 통해서 학습을 종료하시겠습니까? 라는 모달을 띄우고 종료버튼을 누르면 reload하는 방식으로 동작을 변경해야 할 것 같습니다.

### Container시각화 name

Container를 시각화 할 때 name의 값 앞에 `/`가 붙었습니다. `/`가 보이지 않고 이름만 보일 수 있도록 조치했습니다.