### PR TITLE
정적 페이지 렌더링 오류, 퀴즈 설명 수정, 터미널 반응형 최적화

### DIFF
--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -98,8 +98,7 @@ export class QuizService {
                     '컨테이너의 생성과 실행을 한 번에 수행해봅시다.\n\n' +
                     '1. docker run 명령어를 사용하여 learndocker.io/joke 이미지로 컨테이너를 생성하고 실행하세요.\n' +
                     '2. 단 detach 모드로 실행해야 합니다.\n' +
-                    '3. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n' +
-                    '4. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n',
+                    '3. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n',
                 hint: `<ul class="list-disc list-inside">
   <li>docker run --detach <이미지명 | IMAGE ID> 형식으로 명령어를 작성하세요.</li>
 </ul>

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -99,11 +99,9 @@ export class QuizService {
                     '1. docker run 명령어를 사용하여 learndocker.io/joke 이미지로 컨테이너를 생성하고 실행하세요.\n' +
                     '2. 단 detach 모드로 실행해야 합니다.\n' +
                     '3. 이 명령어는 create와 start를 연속으로 실행하는 것과 같은 효과입니다.\n' +
-                    '4. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n' +
-                    '5. 답안란은 페이지 우측 하단에 있습니다.\n',
+                    '4. 실행 후 터미널에 표시되는 문제를 보고 답을 입력해주세요.\n',
                 hint: `<ul class="list-disc list-inside">
   <li>docker run --detach <이미지명 | IMAGE ID> 형식으로 명령어를 작성하세요.</li>
-  <li>이미지는 learndocker.io/joke를 사용하세요.</li>
 </ul>
                 `,
             },
@@ -114,7 +112,7 @@ export class QuizService {
                     'detach로 실행 된 container 로그를 확인해보겠습니다.\n\n' +
                     '1. docker ps -a 명령어를 사용하여 모든 컨테이너 목록을 확인하세요.\n' +
                     '2. learndocker.io/joke 컨테이너의 로그를 확인하세요\n' +
-                    '3. 실행 후 터미널에 표시되는 문제를 보고 한글로 답을 입력해주세요.\n' +
+                    '3. 실행 후 터미널에 표시되는 문제를 보고, 띄어쓰기 없이 한글로 답을 입력해주세요.\n' +
                     '4. 답안란은 페이지 우측 하단에 있습니다.\n',
                 hint: `<ul class="list-disc list-inside">
   <li>docker logs <CONTAINER ID | NAMES>을 사용하세요.</li>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,7 +61,7 @@ const App = () => {
                         dockerImageStates={dockerImageStates}
                         dockerContainerStates={dockerContainerStates}
                     />
-                    <div className='ml-[17rem] mt-16 px-12 py-6 w-full z-0'>
+                    <div className='ml-[17rem] mt-16 px-12 py-6 w-[calc(100vw-17rem)] overflow-y-auto z-0'>
                         <Routes>
                             <Route
                                 path='/'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,7 +61,7 @@ const App = () => {
                         dockerImageStates={dockerImageStates}
                         dockerContainerStates={dockerContainerStates}
                     />
-                    <div className='ml-[17rem] mt-16 px-12 py-6 w-full h-[calc(100vh-4rem)] z-0 overflow-y-auto'>
+                    <div className='ml-[17rem] mt-16 px-12 py-6 w-full z-0'>
                         <Routes>
                             <Route
                                 path='/'

--- a/frontend/src/components/quiz/QuizPage.tsx
+++ b/frontend/src/components/quiz/QuizPage.tsx
@@ -39,7 +39,7 @@ export const QuizContent = ({
                     {quizNodes.description}
                     {visualNodes.visualization}
                 </div>
-                <div className='flex flex-col 2xl:flex-row gap-3 2xl:gap-5 flex-1'>
+                <div className='flex flex-col 2xl:flex-row gap-3 2xl:gap-5 flex-1 flex-wrap'>
                     {visualNodes.terminal}
                     {quizNodes.submit}
                 </div>

--- a/frontend/src/components/quiz/QuizPageWrapper.tsx
+++ b/frontend/src/components/quiz/QuizPageWrapper.tsx
@@ -54,5 +54,5 @@ export const QuizPageWrapper = ({ children, showAlert }: QuizPageWrapperProps) =
         return null;
     }
 
-    return <div className='h-[calc(100vh-4rem)]'>{children(quizId as string)}</div>;
+    return <div className='h-[calc(100vh-7rem)]'>{children(quizId as string)}</div>;
 };

--- a/frontend/src/components/quiz/QuizPageWrapper.tsx
+++ b/frontend/src/components/quiz/QuizPageWrapper.tsx
@@ -54,5 +54,5 @@ export const QuizPageWrapper = ({ children, showAlert }: QuizPageWrapperProps) =
         return null;
     }
 
-    return <>{children(quizId as string)}</>;
+    return <div className='h-[calc(100vh-4rem)]'>{children(quizId as string)}</div>;
 };

--- a/frontend/src/components/quiz/XTerminal.tsx
+++ b/frontend/src/components/quiz/XTerminal.tsx
@@ -23,7 +23,7 @@ const XTerminal = ({ updateVisualizationData, hostStatus, showAlert }: XTerminal
     useEffect(() => {
         if (!terminalRef.current) return;
 
-        const { terminal, clipboardProvider } = createTerminal(terminalRef.current);
+        const { terminal, clipboardProvider, fitAddon } = createTerminal(terminalRef.current);
         terminalInstanceRef.current = terminal;
         loadingRef.current = new LoadingTerminal(terminal);
         clipboardProviderRef.current = clipboardProvider;
@@ -34,6 +34,7 @@ const XTerminal = ({ updateVisualizationData, hostStatus, showAlert }: XTerminal
         } else {
             terminal.write('~$ ');
         }
+        fitAddon.fit();
 
         return () => terminal.dispose();
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -62,7 +63,7 @@ const XTerminal = ({ updateVisualizationData, hostStatus, showAlert }: XTerminal
     }, [hostStatus]);
 
     return (
-        <div className='border rounded-lg border-black bg-black flex-1'>
+        <div className='border rounded-lg border-black bg-black flex-1 min-w-0'>
             <div ref={terminalRef} className='p-2 custom-terminal h-full' />
         </div>
     );

--- a/frontend/src/components/staticpages/DockerContainerLifeCyclePage.tsx
+++ b/frontend/src/components/staticpages/DockerContainerLifeCyclePage.tsx
@@ -14,7 +14,7 @@ const DockerContainerLifeCyclePage = () => {
                 <div data-aos='fade-left'>
                     <h2 className='text-2xl font-bold'>Container의 상태</h2>
                     <div className='bg-Moby-Blue text-black mt-4 bg-opacity-15 rounded-lg shadow-md p-2'>
-                        <p className='mb-5'>
+                        <p className='py-2'>
                             컨테이너는{' '}
                             <span className='font-bold text-blue-800'>
                                 생성, 실행, 중지 등 다양한 상태를 가지며, Docker 명령어를 통해
@@ -26,7 +26,7 @@ const DockerContainerLifeCyclePage = () => {
 
                     <h3 className='text-xl font-bold mt-10'>1. Created</h3>
                     <div className='bg-Moby-Blue mt-2 bg-opacity-15 rounded-lg p-2'>
-                        <p>
+                        <p className='py-1'>
                             도커 이미지로부터 도커 컨테이너가 생성된 상태이며 컨테이너가 실행된
                             상태는 아닙니다.
                         </p>
@@ -34,14 +34,14 @@ const DockerContainerLifeCyclePage = () => {
 
                     <h3 className='text-xl font-bold mt-10'>2. Running</h3>
                     <div className='bg-Moby-Blue mt-2 bg-opacity-15 rounded-lg p-2'>
-                        <p>
+                        <p className='py-1'>
                             docker start 또는 docker run 명령어로 시작된, 실행 중인 컨테이너입니다.
                         </p>
                     </div>
 
                     <h3 className='text-xl font-bold mt-10'>3. Stopped</h3>
                     <div className='bg-Moby-Blue mt-2 bg-opacity-15 rounded-lg p-2'>
-                        <p>
+                        <p className='py-1'>
                             컨테이너의 실행이 중지된 상태로 컨테이너의 모든 프로세스가 종료되고,
                             컨테이너가 더 이상 실행되지 않습니다.
                         </p>
@@ -49,12 +49,12 @@ const DockerContainerLifeCyclePage = () => {
 
                     <h3 className='text-xl font-bold mt-10'>4. Paused</h3>
                     <div className='bg-Moby-Blue mt-2 bg-opacity-15 rounded-lg p-2'>
-                        <p>컨테이너 내부의 모든 프로세스가 일시 중단된 상태입니다.</p>
+                        <p className='py-1'>컨테이너 내부의 모든 프로세스가 일시 중단된 상태입니다.</p>
                     </div>
 
                     <h3 className='text-xl font-bold mt-10'>5. Deleted</h3>
                     <div className='bg-Moby-Blue mt-2 bg-opacity-15 rounded-lg p-2'>
-                        <p>Docker 컨테이너가 삭제된 상태입니다.</p>
+                        <p className='py-1'>Docker 컨테이너가 삭제된 상태입니다.</p>
                     </div>
                 </div>
             </div>

--- a/frontend/src/utils/terminalUtils.ts
+++ b/frontend/src/utils/terminalUtils.ts
@@ -6,12 +6,14 @@ import { requestCommandResult } from '../api/quiz';
 export function createTerminal(container: HTMLElement): {
     terminal: Terminal;
     clipboardProvider: BrowserClipboardProvider;
+    fitAddon: FitAddon;
 } {
     const terminal = new Terminal({
         cursorBlink: true,
         fontFamily: '"Noto Sans Mono", "Noto Sans KR", courier-new, courier, monospace',
         fontSize: 14,
         rows: 20,
+        cols: 40,
         fontWeight: '300',
     });
 
@@ -25,10 +27,9 @@ export function createTerminal(container: HTMLElement): {
     terminal.open(container);
 
     const handleResize = () => {
-        terminal.resize(terminal.cols, 20);
+        terminal.resize(40, 20);
         fitAddon.fit();
     };
-    handleResize();
 
     window.addEventListener('resize', handleResize);
 
@@ -39,7 +40,7 @@ export function createTerminal(container: HTMLElement): {
         originalDispose();
     };
 
-    return { terminal, clipboardProvider };
+    return { terminal, clipboardProvider, fitAddon };
 }
 
 const handleClear = (term: Terminal) => {


### PR DESCRIPTION
## 작업 개요

정적 페이지 렌더링 오류, 퀴즈 설명 수정, 터미널 반응형 최적화, 컨테이너 생명주기 페이지 CSS 스타일 수정

## 작업 상세 내용

### 컨테이너 생명주기 페이지 디자인 수정
불필요한 margin 제거하고 padding만 조금 넣었습니다.

기존 페이지
![디자인수정1](https://github.com/user-attachments/assets/72ec8421-0fbf-47d3-a4d8-d4f99150c631)

수정된 페이지
![디자인수정2](https://github.com/user-attachments/assets/3ad9fe6c-aa2a-4853-8274-f541cff8ee48)

### 정적 페이지의 학습 요소 일부가 제대로 렌더링되지 않는 현상
- 퀴즈 페이지와 학습 페이지가 공유하는 공통 부모 Element의 CSS를 건드린 것이 원인이었습니다.
- 퀴즈 페이지에만 필요한 스타일은 퀴즈 페이지에만 적용되도록 수정했습니다.

### 컨테이너 생성 및 실행하기, 컨테이너 로그 확인하기 문제 설명 수정
- 컨테이너 생성 및 실행하기
	- `답안란은 페이지 우측 하단에 있습니다.` 제거
- 컨테이너 로그 확인하기
	- 띄어쓰기 없이 입력하라는 안내 추가

### 터미널 반응형 처리 최적화
- 기존에는 최초 렌더링 시 터미널이 CSS 적용을 못 받았습니다.
- 현재는 렌더링 이후에 fitAddon의 fit 메서드를 호출하도록 조치하고, flex-wrap을 적용하여 terminal이 container 밖으로 빠져나오지 못합니다.
- 다만, 모종의 이유로 깜빡거림이 있는데, 이는 아직 조치하지 못했습니다.