### PR TITLE
fix: 반응형 터미널 적용 시 투명한 터미널 영역이 삐져나오는 상황

### DIFF
--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -99,7 +99,7 @@ const QuizButtons = ({
     };
 
     return (
-        <div className='bottom-0 flex justify-end mb-6'>
+        <div className='flex justify-end mb-6'>
             <section className='flex justify-between gap-6 w-72'>
                 <button
                     className='text-lg text-white rounded-lg bg-gray-300 hover:bg-gray-400 py-2 px-4'

--- a/frontend/src/components/quiz/QuizButtons.tsx
+++ b/frontend/src/components/quiz/QuizButtons.tsx
@@ -99,7 +99,7 @@ const QuizButtons = ({
     };
 
     return (
-        <div className='flex justify-end mb-6'>
+        <div className='bottom-0 flex justify-end mb-6'>
             <section className='flex justify-between gap-6 w-72'>
                 <button
                     className='text-lg text-white rounded-lg bg-gray-300 hover:bg-gray-400 py-2 px-4'

--- a/frontend/src/components/quiz/QuizPage.tsx
+++ b/frontend/src/components/quiz/QuizPage.tsx
@@ -42,10 +42,8 @@ export const QuizContent = ({
                     {quizNodes.description}
                     {visualNodes.visualization}
                 </div>
-                <div className='flex flex-col gap-3 flex-1 flex-wrap'>
-                    {visualNodes.terminal}
-                    {quizNodes.submit}
-                </div>
+                <div className='flex flex-col gap-3 flex-1 flex-wrap'>{visualNodes.terminal}</div>
+                {quizNodes.submit}
             </div>
         </>
     );

--- a/frontend/src/components/quiz/QuizPage.tsx
+++ b/frontend/src/components/quiz/QuizPage.tsx
@@ -42,8 +42,10 @@ export const QuizContent = ({
                     {quizNodes.description}
                     {visualNodes.visualization}
                 </div>
-                <div className='flex flex-col gap-3 flex-1 flex-wrap'>{visualNodes.terminal}</div>
-                {quizNodes.submit}
+                <div className='flex flex-col gap-3 flex-1 flex-wrap'>
+                    {visualNodes.terminal}
+                    {quizNodes.submit}
+                </div>
             </div>
         </>
     );

--- a/frontend/src/components/quiz/QuizPage.tsx
+++ b/frontend/src/components/quiz/QuizPage.tsx
@@ -42,7 +42,7 @@ export const QuizContent = ({
                     {quizNodes.description}
                     {visualNodes.visualization}
                 </div>
-                <div className='flex flex-col 2xl:flex-row gap-3 2xl:gap-5 flex-1 flex-wrap'>
+                <div className='flex flex-col gap-3 flex-1 flex-wrap'>
                     {visualNodes.terminal}
                     {quizNodes.submit}
                 </div>

--- a/frontend/src/utils/terminalUtils.ts
+++ b/frontend/src/utils/terminalUtils.ts
@@ -12,7 +12,7 @@ export function createTerminal(container: HTMLElement): {
         cursorBlink: true,
         fontFamily: '"Noto Sans Mono", "Noto Sans KR", courier-new, courier, monospace',
         fontSize: 14,
-        rows: 20,
+        rows: 13,
         fontWeight: '300',
     });
 
@@ -26,7 +26,7 @@ export function createTerminal(container: HTMLElement): {
     terminal.open(container);
 
     const handleResize = () => {
-        terminal.resize(terminal.cols, 20);
+        terminal.resize(4, 13);
         fitAddon.fit();
     };
 

--- a/frontend/src/utils/terminalUtils.ts
+++ b/frontend/src/utils/terminalUtils.ts
@@ -13,7 +13,6 @@ export function createTerminal(container: HTMLElement): {
         fontFamily: '"Noto Sans Mono", "Noto Sans KR", courier-new, courier, monospace',
         fontSize: 14,
         rows: 20,
-        cols: 40,
         fontWeight: '300',
     });
 
@@ -27,7 +26,7 @@ export function createTerminal(container: HTMLElement): {
     terminal.open(container);
 
     const handleResize = () => {
-        terminal.resize(40, 20);
+        terminal.resize(terminal.cols, 20);
         fitAddon.fit();
     };
 


### PR DESCRIPTION
- 눈물을 머금고 반응형을 해제합니다.
- cols를 terminal.cols로 두지 않으니 이번엔 터미널 영역이 보이는 것보다 작아지는 문제가 있어서 기존의 방법을 적용했습니다.