### PR TITLE
fix: imageName으로만 채점되는 버그 수정

### DIFF
--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -281,10 +281,10 @@ export class QuizService {
     }
 
     private async submitQuiz4(sessionId: string, containerPort: string, level: number) {
-        const validImage = ['learndocker.io/hello-world'];
+        const validCommand = '/hello';
         const containers = await this.sandboxService.getUserContainers(containerPort);
         const result = containers.filter((container: Record<string, any>) =>
-            validImage.includes(container.Image)
+            container.Command.includes(validCommand)
         );
         if (result.length > 0) {
             this.updateLevel(sessionId, level, 5);
@@ -306,14 +306,14 @@ export class QuizService {
     }
 
     private async submitQuiz6(sessionId: string, containerPort: string, level: number) {
-        const validImage = ['learndocker.io/joke'];
+        const validCommand = '/joke';
         const containers = await this.sandboxService.getUserContainers(containerPort);
         if (containers.length === 0) {
             return { quizResult: 'FAIL' };
         }
 
         const result = containers.some((container: Record<string, any>) => {
-            return container.State === 'running' && validImage.includes(container.Image);
+            return container.State === 'running' && container.Command.includes(validCommand);
         });
 
         if (result) {


### PR DESCRIPTION
- 컨테이너를 imageId로 실행하는 경우 채점이 안되는 버그가 있었습니다.
![bug](https://github.com/user-attachments/assets/d181602a-5938-4a55-8031-2b682d07d88c)
- imageId로 실행하는 경우 image가 실행할 때 적은 imageId로 저장되기 때문에 채점이 되지 않았습니다.
- command로 체크하는 것으로 수정했습니다.
